### PR TITLE
Add script to inject decoded content fields

### DIFF
--- a/provenance/decode-att-content.sh
+++ b/provenance/decode-att-content.sh
@@ -1,0 +1,44 @@
+#!/bin/env bash
+# Copyright 2023 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+# Find all the attestation files
+ATTESTATIONS=$( find ./recordings -name attestation.json )
+
+# If a content field is found, assume it contains base64
+# encoded json, and insert a new field with the decoded object.
+JQ_QUERY='
+  walk(
+    if type == "object" and .content? then
+      .__decodedContent = (.content | @base64d | fromjson)
+    else
+      .
+    end
+  )
+'
+
+TMP_OUTPUT=/tmp/decoded-content-att.json
+for att in $ATTESTATIONS; do
+  # Apply the transformation
+  jq "$JQ_QUERY" $att > $TMP_OUTPUT
+
+  # Keep the output only if there were changes
+  diff $att $TMP_OUTPUT >/dev/null || cp $TMP_OUTPUT $(dirname $att)
+done

--- a/provenance/recordings/03-SLSA-v1-0-plain-build-type-Pipeline-in-cluster/decoded-content-att.json
+++ b/provenance/recordings/03-SLSA-v1-0-plain-build-type-Pipeline-in-cluster/decoded-content-att.json
@@ -1,0 +1,139 @@
+{
+  "_type": "https://in-toto.io/Statement/v0.1",
+  "predicateType": "https://slsa.dev/provenance/v1",
+  "subject": [
+    {
+      "name": "quay.io/lucarval/test-policies-chains",
+      "digest": {
+        "sha256": "617723502cc79e286b13e2419334f2a6f64c1f46575d3de7e9df2e65a872fd9f"
+      }
+    }
+  ],
+  "predicate": {
+    "buildDefinition": {
+      "buildType": "https://tekton.dev/chains/v2/slsa",
+      "externalParameters": {
+        "runSpec": {
+          "pipelineRef": {
+            "name": "simple-build"
+          },
+          "params": [
+            {
+              "name": "IMAGE_DIGEST",
+              "value": "sha256:617723502cc79e286b13e2419334f2a6f64c1f46575d3de7e9df2e65a872fd9f"
+            },
+            {
+              "name": "IMAGE_URL",
+              "value": "quay.io/lucarval/test-policies-chains"
+            },
+            {
+              "name": "TEST_OUTPUT",
+              "value": "missing"
+            },
+            {
+              "name": "commit",
+              "value": "24d88836110dca40cce6a3ac16e3e682c2a331b3"
+            },
+            {
+              "name": "committer-date",
+              "value": "1697558986"
+            },
+            {
+              "name": "url",
+              "value": "gitspam.spam/spam/spam"
+            }
+          ],
+          "serviceAccountName": "default",
+          "timeouts": {
+            "pipeline": "1h0m0s"
+          }
+        }
+      },
+      "internalParameters": {
+        "tekton-pipelines-feature-flags": {
+          "DisableAffinityAssistant": false,
+          "DisableCredsInit": false,
+          "RunningInEnvWithInjectedSidecars": true,
+          "RequireGitSSHSecretKnownHosts": false,
+          "EnableTektonOCIBundles": false,
+          "ScopeWhenExpressionsToTask": false,
+          "EnableAPIFields": "beta",
+          "SendCloudEventsForRuns": false,
+          "AwaitSidecarReadiness": true,
+          "EnforceNonfalsifiability": "none",
+          "VerificationNoMatchPolicy": "ignore",
+          "EnableProvenanceInStatus": true,
+          "ResultExtractionMethod": "termination-message",
+          "MaxResultSize": 4096,
+          "SetSecurityContext": false,
+          "Coschedule": "workspaces"
+        }
+      },
+      "resolvedDependencies": [
+        {
+          "uri": "git+https://github.com/lcarva/ec-policies.git",
+          "digest": {
+            "sha1": "727f8cae69fdfbae7cf8a44fd5e2055ad9573fb9"
+          },
+          "name": "pipelineTask"
+        },
+        {
+          "uri": "oci://registry.access.redhat.com/ubi9",
+          "digest": {
+            "sha256": "20f695d2a91352d4eaa25107535126727b5945bff38ed36a3e59590f495046f0"
+          }
+        },
+        {
+          "uri": "quay.io/lucarval/test-policies-chains",
+          "digest": {
+            "sha256": "a26916e6abb8c89127b13c58674447a8e49ef5c573434106cd97033dc164ec09"
+          },
+          "name": "pipelineTask"
+        },
+        {
+          "uri": "git+gitspam.spam/spam/spam.git",
+          "digest": {
+            "sha1": "24d88836110dca40cce6a3ac16e3e682c2a331b3"
+          },
+          "name": "inputs/result"
+        }
+      ]
+    },
+    "runDetails": {
+      "builder": {
+        "id": "https://tekton.dev/chains/v2"
+      },
+      "metadata": {
+        "invocationID": "75531c64-3775-4fbe-a5dd-25d5eda0d60f",
+        "startedOn": "2023-10-17T16:09:46Z",
+        "finishedOn": "2023-10-17T16:09:59Z"
+      },
+      "byproducts": [
+        {
+          "name": "pipelineRunResults/IMAGE_URL",
+          "mediaType": "application/json",
+          "content": "InF1YXkuaW8vbHVjYXJ2YWwvdGVzdC1wb2xpY2llcy1jaGFpbnMi",
+          "__decodedContent": "quay.io/lucarval/test-policies-chains"
+        },
+        {
+          "name": "pipelineRunResults/IMAGE_DIGEST",
+          "mediaType": "application/json",
+          "content": "InNoYTI1Njo2MTc3MjM1MDJjYzc5ZTI4NmIxM2UyNDE5MzM0ZjJhNmY2NGMxZjQ2NTc1ZDNkZTdlOWRmMmU2NWE4NzJmZDlmIg==",
+          "__decodedContent": "sha256:617723502cc79e286b13e2419334f2a6f64c1f46575d3de7e9df2e65a872fd9f"
+        },
+        {
+          "name": "pipelineRunResults/CHAINS-GIT_URL",
+          "mediaType": "application/json",
+          "content": "ImdpdHNwYW0uc3BhbS9zcGFtL3NwYW0i",
+          "__decodedContent": "gitspam.spam/spam/spam"
+        },
+        {
+          "name": "pipelineRunResults/CHAINS-GIT_COMMIT",
+          "mediaType": "application/json",
+          "content": "IjI0ZDg4ODM2MTEwZGNhNDBjY2U2YTNhYzE2ZTNlNjgyYzJhMzMxYjMi",
+          "__decodedContent": "24d88836110dca40cce6a3ac16e3e682c2a331b3"
+        }
+      ]
+    }
+  }
+}

--- a/provenance/recordings/04-SLSA-v1-0-plain-build-type-Pipeline-inline/decoded-content-att.json
+++ b/provenance/recordings/04-SLSA-v1-0-plain-build-type-Pipeline-inline/decoded-content-att.json
@@ -1,0 +1,302 @@
+{
+  "_type": "https://in-toto.io/Statement/v0.1",
+  "predicateType": "https://slsa.dev/provenance/v1",
+  "subject": [
+    {
+      "name": "quay.io/lucarval/test-policies-chains",
+      "digest": {
+        "sha256": "7cd8d408a6184e0923cef34cc6a8b2f012c9faef337272677adf093e3ea73c2a"
+      }
+    }
+  ],
+  "predicate": {
+    "buildDefinition": {
+      "buildType": "https://tekton.dev/chains/v2/slsa",
+      "externalParameters": {
+        "runSpec": {
+          "pipelineSpec": {
+            "tasks": [
+              {
+                "name": "git-clone",
+                "taskRef": {
+                  "kind": "Task",
+                  "resolver": "git",
+                  "params": [
+                    {
+                      "name": "url",
+                      "value": "https://github.com/lcarva/ec-policies.git"
+                    },
+                    {
+                      "name": "revision",
+                      "value": "727f8cae69fdfbae7cf8a44fd5e2055ad9573fb9"
+                    },
+                    {
+                      "name": "pathInRepo",
+                      "value": "integration/task/mock-git-clone.yaml"
+                    }
+                  ]
+                },
+                "params": [
+                  {
+                    "name": "commit",
+                    "value": "$(params.commit)"
+                  },
+                  {
+                    "name": "url",
+                    "value": "$(params.url)"
+                  },
+                  {
+                    "name": "committer-date",
+                    "value": "$(params.committer-date)"
+                  }
+                ]
+              },
+              {
+                "name": "scan",
+                "taskSpec": {
+                  "spec": null,
+                  "metadata": {},
+                  "params": [
+                    {
+                      "name": "TEST_OUTPUT",
+                      "type": "string",
+                      "description": "The value to of the TEST_OUTPUT commit result."
+                    }
+                  ],
+                  "description": "This is a dummy task that emulates a task that scans source code. Its sole purpose is to facilitate testing.",
+                  "steps": [
+                    {
+                      "name": "scan",
+                      "image": "registry.access.redhat.com/ubi9:latest",
+                      "env": [
+                        {
+                          "name": "TEST_OUTPUT",
+                          "value": "$(params.TEST_OUTPUT)"
+                        }
+                      ],
+                      "resources": {},
+                      "script": "#!/usr/bin/env sh\nset -euo pipefail\n\necho -n \"${TEST_OUTPUT}\" > \"$(results.TEST_OUTPUT.path)\"\n"
+                    }
+                  ],
+                  "results": [
+                    {
+                      "name": "TEST_OUTPUT",
+                      "type": "string",
+                      "description": "The summary scanner output."
+                    }
+                  ]
+                },
+                "runAfter": [
+                  "git-clone"
+                ],
+                "params": [
+                  {
+                    "name": "TEST_OUTPUT",
+                    "value": "$(params.TEST_OUTPUT)"
+                  }
+                ]
+              },
+              {
+                "name": "build",
+                "taskRef": {
+                  "kind": "Task",
+                  "resolver": "bundles",
+                  "params": [
+                    {
+                      "name": "bundle",
+                      "value": "quay.io/lucarval/test-policies-chains@sha256:eddc8ae8a13347bd8fdaa1843cc62eac9d3cc12801cd48fe858c087bfba9bd7f"
+                    },
+                    {
+                      "name": "name",
+                      "value": "mock-build"
+                    },
+                    {
+                      "name": "kind",
+                      "value": "task"
+                    }
+                  ]
+                },
+                "runAfter": [
+                  "scan"
+                ],
+                "params": [
+                  {
+                    "name": "IMAGE_URL",
+                    "value": "$(params.IMAGE_URL)"
+                  },
+                  {
+                    "name": "IMAGE_DIGEST",
+                    "value": "$(params.IMAGE_DIGEST)"
+                  }
+                ]
+              }
+            ],
+            "params": [
+              {
+                "name": "commit",
+                "type": "string"
+              },
+              {
+                "name": "url",
+                "type": "string"
+              },
+              {
+                "name": "committer-date",
+                "type": "string"
+              },
+              {
+                "name": "IMAGE_URL",
+                "type": "string"
+              },
+              {
+                "name": "IMAGE_DIGEST",
+                "type": "string"
+              },
+              {
+                "name": "TEST_OUTPUT",
+                "type": "string"
+              }
+            ],
+            "results": [
+              {
+                "name": "IMAGE_URL",
+                "description": "",
+                "value": "$(tasks.build.results.IMAGE_URL)"
+              },
+              {
+                "name": "IMAGE_DIGEST",
+                "description": "",
+                "value": "$(tasks.build.results.IMAGE_DIGEST)"
+              },
+              {
+                "name": "CHAINS-GIT_URL",
+                "description": "",
+                "value": "$(tasks.git-clone.results.url)"
+              },
+              {
+                "name": "CHAINS-GIT_COMMIT",
+                "description": "",
+                "value": "$(tasks.git-clone.results.commit)"
+              }
+            ]
+          },
+          "params": [
+            {
+              "name": "IMAGE_DIGEST",
+              "value": "sha256:7cd8d408a6184e0923cef34cc6a8b2f012c9faef337272677adf093e3ea73c2a"
+            },
+            {
+              "name": "IMAGE_URL",
+              "value": "quay.io/lucarval/test-policies-chains"
+            },
+            {
+              "name": "TEST_OUTPUT",
+              "value": "missing"
+            },
+            {
+              "name": "commit",
+              "value": "fc98226c7a4206e9b4e9fe99172ddc3a5ae6edfa"
+            },
+            {
+              "name": "committer-date",
+              "value": "1697559014"
+            },
+            {
+              "name": "url",
+              "value": "gitspam.spam/spam/spam"
+            }
+          ],
+          "serviceAccountName": "default",
+          "timeouts": {
+            "pipeline": "1h0m0s"
+          }
+        }
+      },
+      "internalParameters": {
+        "tekton-pipelines-feature-flags": {
+          "DisableAffinityAssistant": false,
+          "DisableCredsInit": false,
+          "RunningInEnvWithInjectedSidecars": true,
+          "RequireGitSSHSecretKnownHosts": false,
+          "EnableTektonOCIBundles": false,
+          "ScopeWhenExpressionsToTask": false,
+          "EnableAPIFields": "beta",
+          "SendCloudEventsForRuns": false,
+          "AwaitSidecarReadiness": true,
+          "EnforceNonfalsifiability": "none",
+          "VerificationNoMatchPolicy": "ignore",
+          "EnableProvenanceInStatus": true,
+          "ResultExtractionMethod": "termination-message",
+          "MaxResultSize": 4096,
+          "SetSecurityContext": false,
+          "Coschedule": "workspaces"
+        }
+      },
+      "resolvedDependencies": [
+        {
+          "uri": "git+https://github.com/lcarva/ec-policies.git",
+          "digest": {
+            "sha1": "727f8cae69fdfbae7cf8a44fd5e2055ad9573fb9"
+          },
+          "name": "pipelineTask"
+        },
+        {
+          "uri": "oci://registry.access.redhat.com/ubi9",
+          "digest": {
+            "sha256": "20f695d2a91352d4eaa25107535126727b5945bff38ed36a3e59590f495046f0"
+          }
+        },
+        {
+          "uri": "quay.io/lucarval/test-policies-chains",
+          "digest": {
+            "sha256": "eddc8ae8a13347bd8fdaa1843cc62eac9d3cc12801cd48fe858c087bfba9bd7f"
+          },
+          "name": "pipelineTask"
+        },
+        {
+          "uri": "git+gitspam.spam/spam/spam.git",
+          "digest": {
+            "sha1": "fc98226c7a4206e9b4e9fe99172ddc3a5ae6edfa"
+          },
+          "name": "inputs/result"
+        }
+      ]
+    },
+    "runDetails": {
+      "builder": {
+        "id": "https://tekton.dev/chains/v2"
+      },
+      "metadata": {
+        "invocationID": "3db243c8-57cc-47ea-847d-93a1e17bbe79",
+        "startedOn": "2023-10-17T16:10:14Z",
+        "finishedOn": "2023-10-17T16:10:29Z"
+      },
+      "byproducts": [
+        {
+          "name": "pipelineRunResults/IMAGE_URL",
+          "mediaType": "application/json",
+          "content": "InF1YXkuaW8vbHVjYXJ2YWwvdGVzdC1wb2xpY2llcy1jaGFpbnMi",
+          "__decodedContent": "quay.io/lucarval/test-policies-chains"
+        },
+        {
+          "name": "pipelineRunResults/IMAGE_DIGEST",
+          "mediaType": "application/json",
+          "content": "InNoYTI1Njo3Y2Q4ZDQwOGE2MTg0ZTA5MjNjZWYzNGNjNmE4YjJmMDEyYzlmYWVmMzM3MjcyNjc3YWRmMDkzZTNlYTczYzJhIg==",
+          "__decodedContent": "sha256:7cd8d408a6184e0923cef34cc6a8b2f012c9faef337272677adf093e3ea73c2a"
+        },
+        {
+          "name": "pipelineRunResults/CHAINS-GIT_URL",
+          "mediaType": "application/json",
+          "content": "ImdpdHNwYW0uc3BhbS9zcGFtL3NwYW0i",
+          "__decodedContent": "gitspam.spam/spam/spam"
+        },
+        {
+          "name": "pipelineRunResults/CHAINS-GIT_COMMIT",
+          "mediaType": "application/json",
+          "content": "ImZjOTgyMjZjN2E0MjA2ZTliNGU5ZmU5OTE3MmRkYzNhNWFlNmVkZmEi",
+          "__decodedContent": "fc98226c7a4206e9b4e9fe99172ddc3a5ae6edfa"
+        }
+      ]
+    }
+  }
+}

--- a/provenance/recordings/05-SLSA-v1-0-tekton-build-type-Pipeline-in-cluster/decoded-content-att.json
+++ b/provenance/recordings/05-SLSA-v1-0-tekton-build-type-Pipeline-in-cluster/decoded-content-att.json
@@ -1,0 +1,1027 @@
+{
+  "_type": "https://in-toto.io/Statement/v0.1",
+  "predicateType": "https://slsa.dev/provenance/v1",
+  "subject": [
+    {
+      "name": "quay.io/lucarval/test-policies-chains",
+      "digest": {
+        "sha256": "f6135ba64031dff85c0a9771776ad03135fecad75f572cb13917bd139f8c377c"
+      }
+    }
+  ],
+  "predicate": {
+    "buildDefinition": {
+      "buildType": "https://tekton.dev/chains/v2/slsa-tekton",
+      "externalParameters": {
+        "runSpec": {
+          "pipelineRef": {
+            "name": "simple-build"
+          },
+          "params": [
+            {
+              "name": "IMAGE_DIGEST",
+              "value": "sha256:f6135ba64031dff85c0a9771776ad03135fecad75f572cb13917bd139f8c377c"
+            },
+            {
+              "name": "IMAGE_URL",
+              "value": "quay.io/lucarval/test-policies-chains"
+            },
+            {
+              "name": "TEST_OUTPUT",
+              "value": "missing"
+            },
+            {
+              "name": "commit",
+              "value": "f6aec6868913800133e2c61fb3183286ffd1551a"
+            },
+            {
+              "name": "committer-date",
+              "value": "1697559044"
+            },
+            {
+              "name": "url",
+              "value": "gitspam.spam/spam/spam"
+            }
+          ],
+          "serviceAccountName": "default",
+          "timeouts": {
+            "pipeline": "1h0m0s"
+          }
+        }
+      },
+      "internalParameters": {
+        "annotations": null,
+        "labels": {
+          "tekton.dev/pipeline": "simple-build"
+        },
+        "tekton-pipelines-feature-flags": {
+          "DisableAffinityAssistant": false,
+          "DisableCredsInit": false,
+          "RunningInEnvWithInjectedSidecars": true,
+          "RequireGitSSHSecretKnownHosts": false,
+          "EnableTektonOCIBundles": false,
+          "ScopeWhenExpressionsToTask": false,
+          "EnableAPIFields": "beta",
+          "SendCloudEventsForRuns": false,
+          "AwaitSidecarReadiness": true,
+          "EnforceNonfalsifiability": "none",
+          "VerificationNoMatchPolicy": "ignore",
+          "EnableProvenanceInStatus": true,
+          "ResultExtractionMethod": "termination-message",
+          "MaxResultSize": 4096,
+          "SetSecurityContext": false,
+          "Coschedule": "workspaces"
+        }
+      },
+      "resolvedDependencies": [
+        {
+          "uri": "git+https://github.com/lcarva/ec-policies.git",
+          "digest": {
+            "sha1": "727f8cae69fdfbae7cf8a44fd5e2055ad9573fb9"
+          },
+          "name": "pipelineTask",
+          "content": "eyJtZXRhZGF0YSI6eyJuYW1lIjoic2ltcGxlLWJ1aWxkLXJ1bi1lMDlkNjBmZTU2LWdpdC1jbG9uZSIsIm5hbWVzcGFjZSI6ImRlZmF1bHQiLCJ1aWQiOiI4NDY0YzQxMC05YWM4LTQ1N2EtOGU2My04M2NiMGJkOTY0ZjQiLCJyZXNvdXJjZVZlcnNpb24iOiIyMDMxIiwiZ2VuZXJhdGlvbiI6MSwiY3JlYXRpb25UaW1lc3RhbXAiOiIyMDIzLTEwLTE3VDE2OjEwOjQ1WiIsImxhYmVscyI6eyJhcHAua3ViZXJuZXRlcy5pby9tYW5hZ2VkLWJ5IjoidGVrdG9uLXBpcGVsaW5lcyIsInRla3Rvbi5kZXYvbWVtYmVyT2YiOiJ0YXNrcyIsInRla3Rvbi5kZXYvcGlwZWxpbmUiOiJzaW1wbGUtYnVpbGQiLCJ0ZWt0b24uZGV2L3BpcGVsaW5lUnVuIjoic2ltcGxlLWJ1aWxkLXJ1bi1lMDlkNjBmZTU2IiwidGVrdG9uLmRldi9waXBlbGluZVRhc2siOiJnaXQtY2xvbmUiLCJ0ZWt0b24uZGV2L3Rhc2siOiJtb2NrLWdpdC1jbG9uZSJ9LCJhbm5vdGF0aW9ucyI6eyJjaGFpbnMudGVrdG9uLmRldi9zaWduZWQiOiJ0cnVlIiwicGlwZWxpbmUudGVrdG9uLmRldi9yZWxlYXNlIjoiZTdiNWU1OCJ9LCJvd25lclJlZmVyZW5jZXMiOlt7ImFwaVZlcnNpb24iOiJ0ZWt0b24uZGV2L3YxIiwia2luZCI6IlBpcGVsaW5lUnVuIiwibmFtZSI6InNpbXBsZS1idWlsZC1ydW4tZTA5ZDYwZmU1NiIsInVpZCI6IjYxMzAyYmJjLWU4YzYtNDA1OS05NjkyLTkyMDM2YzljMDY5MSIsImNvbnRyb2xsZXIiOnRydWUsImJsb2NrT3duZXJEZWxldGlvbiI6dHJ1ZX1dLCJmaW5hbGl6ZXJzIjpbImNoYWlucy50ZWt0b24uZGV2Il0sIm1hbmFnZWRGaWVsZHMiOlt7Im1hbmFnZXIiOiJjb250cm9sbGVyIiwib3BlcmF0aW9uIjoiVXBkYXRlIiwiYXBpVmVyc2lvbiI6InRla3Rvbi5kZXYvdjEiLCJ0aW1lIjoiMjAyMy0xMC0xN1QxNjoxMDo0NVoiLCJmaWVsZHNUeXBlIjoiRmllbGRzVjEiLCJmaWVsZHNWMSI6eyJmOm1ldGFkYXRhIjp7ImY6YW5ub3RhdGlvbnMiOnsiLiI6e30sImY6cGlwZWxpbmUudGVrdG9uLmRldi9yZWxlYXNlIjp7fX0sImY6bGFiZWxzIjp7Ii4iOnt9LCJmOnRla3Rvbi5kZXYvbWVtYmVyT2YiOnt9LCJmOnRla3Rvbi5kZXYvcGlwZWxpbmUiOnt9LCJmOnRla3Rvbi5kZXYvcGlwZWxpbmVSdW4iOnt9LCJmOnRla3Rvbi5kZXYvcGlwZWxpbmVUYXNrIjp7fSwiZjp0ZWt0b24uZGV2L3Rhc2siOnt9fSwiZjpvd25lclJlZmVyZW5jZXMiOnsiLiI6e30sIms6e1widWlkXCI6XCI2MTMwMmJiYy1lOGM2LTQwNTktOTY5Mi05MjAzNmM5YzA2OTFcIn0iOnt9fX0sImY6c3BlYyI6eyIuIjp7fSwiZjpwYXJhbXMiOnt9LCJmOnNlcnZpY2VBY2NvdW50TmFtZSI6e30sImY6dGFza1JlZiI6eyIuIjp7fSwiZjpraW5kIjp7fSwiZjpwYXJhbXMiOnt9LCJmOnJlc29sdmVyIjp7fX19fX0seyJtYW5hZ2VyIjoiY29udHJvbGxlciIsIm9wZXJhdGlvbiI6IlVwZGF0ZSIsImFwaVZlcnNpb24iOiJ0ZWt0b24uZGV2L3YxIiwidGltZSI6IjIwMjMtMTAtMTdUMTY6MTA6NDlaIiwiZmllbGRzVHlwZSI6IkZpZWxkc1YxIiwiZmllbGRzVjEiOnsiZjpzdGF0dXMiOnsiZjpjb21wbGV0aW9uVGltZSI6e30sImY6Y29uZGl0aW9ucyI6e30sImY6cG9kTmFtZSI6e30sImY6cHJvdmVuYW5jZSI6eyIuIjp7fSwiZjpmZWF0dXJlRmxhZ3MiOnsiLiI6e30sImY6QXdhaXRTaWRlY2FyUmVhZGluZXNzIjp7fSwiZjpDb3NjaGVkdWxlIjp7fSwiZjpEaXNhYmxlQWZmaW5pdHlBc3Npc3RhbnQiOnt9LCJmOkRpc2FibGVDcmVkc0luaXQiOnt9LCJmOkVuYWJsZUFQSUZpZWxkcyI6e30sImY6RW5hYmxlUHJvdmVuYW5jZUluU3RhdHVzIjp7fSwiZjpFbmFibGVUZWt0b25PQ0lCdW5kbGVzIjp7fSwiZjpFbmZvcmNlTm9uZmFsc2lmaWFiaWxpdHkiOnt9LCJmOk1heFJlc3VsdFNpemUiOnt9LCJmOlJlcXVpcmVHaXRTU0hTZWNyZXRLbm93bkhvc3RzIjp7fSwiZjpSZXN1bHRFeHRyYWN0aW9uTWV0aG9kIjp7fSwiZjpSdW5uaW5nSW5FbnZXaXRoSW5qZWN0ZWRTaWRlY2FycyI6e30sImY6U2NvcGVXaGVuRXhwcmVzc2lvbnNUb1Rhc2siOnt9LCJmOlNlbmRDbG91ZEV2ZW50c0ZvclJ1bnMiOnt9LCJmOlNldFNlY3VyaXR5Q29udGV4dCI6e30sImY6VmVyaWZpY2F0aW9uTm9NYXRjaFBvbGljeSI6e319LCJmOnJlZlNvdXJjZSI6eyIuIjp7fSwiZjpkaWdlc3QiOnsiLiI6e30sImY6c2hhMSI6e319LCJmOmVudHJ5UG9pbnQiOnt9LCJmOnVyaSI6e319fSwiZjpyZXN1bHRzIjp7fSwiZjpzdGFydFRpbWUiOnt9LCJmOnN0ZXBzIjp7fSwiZjp0YXNrU3BlYyI6eyIuIjp7fSwiZjpkZXNjcmlwdGlvbiI6e30sImY6cGFyYW1zIjp7fSwiZjpyZXN1bHRzIjp7fSwiZjpzdGVwcyI6e319fX0sInN1YnJlc291cmNlIjoic3RhdHVzIn0seyJtYW5hZ2VyIjoiY29udHJvbGxlciIsIm9wZXJhdGlvbiI6IlVwZGF0ZSIsImFwaVZlcnNpb24iOiJ0ZWt0b24uZGV2L3YxYmV0YTEiLCJ0aW1lIjoiMjAyMy0xMC0xN1QxNjoxMDo1MFoiLCJmaWVsZHNUeXBlIjoiRmllbGRzVjEiLCJmaWVsZHNWMSI6eyJmOm1ldGFkYXRhIjp7ImY6YW5ub3RhdGlvbnMiOnsiZjpjaGFpbnMudGVrdG9uLmRldi9zaWduZWQiOnt9fSwiZjpmaW5hbGl6ZXJzIjp7Ii4iOnt9LCJ2OlwiY2hhaW5zLnRla3Rvbi5kZXZcIiI6e319fX19XX0sInNwZWMiOnsicGFyYW1zIjpbeyJuYW1lIjoiY29tbWl0IiwidmFsdWUiOiJmNmFlYzY4Njg5MTM4MDAxMzNlMmM2MWZiMzE4MzI4NmZmZDE1NTFhIn0seyJuYW1lIjoidXJsIiwidmFsdWUiOiJnaXRzcGFtLnNwYW0vc3BhbS9zcGFtIn0seyJuYW1lIjoiY29tbWl0dGVyLWRhdGUiLCJ2YWx1ZSI6IjE2OTc1NTkwNDQifV0sInNlcnZpY2VBY2NvdW50TmFtZSI6ImRlZmF1bHQiLCJ0YXNrUmVmIjp7ImtpbmQiOiJUYXNrIiwicmVzb2x2ZXIiOiJnaXQiLCJwYXJhbXMiOlt7Im5hbWUiOiJ1cmwiLCJ2YWx1ZSI6Imh0dHBzOi8vZ2l0aHViLmNvbS9sY2FydmEvZWMtcG9saWNpZXMuZ2l0In0seyJuYW1lIjoicmV2aXNpb24iLCJ2YWx1ZSI6IjcyN2Y4Y2FlNjlmZGZiYWU3Y2Y4YTQ0ZmQ1ZTIwNTVhZDk1NzNmYjkifSx7Im5hbWUiOiJwYXRoSW5SZXBvIiwidmFsdWUiOiJpbnRlZ3JhdGlvbi90YXNrL21vY2stZ2l0LWNsb25lLnlhbWwifV19LCJ0aW1lb3V0IjoiMWgwbTBzIn0sInN0YXR1cyI6eyJjb25kaXRpb25zIjpbeyJ0eXBlIjoiU3VjY2VlZGVkIiwic3RhdHVzIjoiVHJ1ZSIsImxhc3RUcmFuc2l0aW9uVGltZSI6IjIwMjMtMTAtMTdUMTY6MTA6NDlaIiwicmVhc29uIjoiU3VjY2VlZGVkIiwibWVzc2FnZSI6IkFsbCBTdGVwcyBoYXZlIGNvbXBsZXRlZCBleGVjdXRpbmcifV0sInBvZE5hbWUiOiJzaW1wbGUtYnVpbGQtcnVuLWUwOWQ2MGZlNTYtZ2l0LWNsb25lLXBvZCIsInN0YXJ0VGltZSI6IjIwMjMtMTAtMTdUMTY6MTA6NDVaIiwiY29tcGxldGlvblRpbWUiOiIyMDIzLTEwLTE3VDE2OjEwOjQ5WiIsInN0ZXBzIjpbeyJ0ZXJtaW5hdGVkIjp7ImV4aXRDb2RlIjowLCJyZWFzb24iOiJDb21wbGV0ZWQiLCJtZXNzYWdlIjoiW3tcImtleVwiOlwiY29tbWl0XCIsXCJ2YWx1ZVwiOlwiZjZhZWM2ODY4OTEzODAwMTMzZTJjNjFmYjMxODMyODZmZmQxNTUxYVwiLFwidHlwZVwiOjF9LHtcImtleVwiOlwiY29tbWl0dGVyLWRhdGVcIixcInZhbHVlXCI6XCIxNjk3NTU5MDQ0XCIsXCJ0eXBlXCI6MX0se1wia2V5XCI6XCJ1cmxcIixcInZhbHVlXCI6XCJnaXRzcGFtLnNwYW0vc3BhbS9zcGFtXCIsXCJ0eXBlXCI6MX1dIiwic3RhcnRlZEF0IjoiMjAyMy0xMC0xN1QxNjoxMDo0OVoiLCJmaW5pc2hlZEF0IjoiMjAyMy0xMC0xN1QxNjoxMDo0OVoiLCJjb250YWluZXJJRCI6ImNvbnRhaW5lcmQ6Ly9mZjNlNzZiZDdjODg2YmMxNTk3NDIwZGQ1MTczODIzNjIzN2M0MzQ2ZmQ3NGQ2MmE3MTBmNGJhZmM3NTY3YWYzIn0sIm5hbWUiOiJjbG9uZSIsImNvbnRhaW5lciI6InN0ZXAtY2xvbmUiLCJpbWFnZUlEIjoicmVnaXN0cnkuYWNjZXNzLnJlZGhhdC5jb20vdWJpOUBzaGEyNTY6MjBmNjk1ZDJhOTEzNTJkNGVhYTI1MTA3NTM1MTI2NzI3YjU5NDViZmYzOGVkMzZhM2U1OTU5MGY0OTUwNDZmMCJ9XSwidGFza1Jlc3VsdHMiOlt7Im5hbWUiOiJjb21taXQiLCJ0eXBlIjoic3RyaW5nIiwidmFsdWUiOiJmNmFlYzY4Njg5MTM4MDAxMzNlMmM2MWZiMzE4MzI4NmZmZDE1NTFhIn0seyJuYW1lIjoiY29tbWl0dGVyLWRhdGUiLCJ0eXBlIjoic3RyaW5nIiwidmFsdWUiOiIxNjk3NTU5MDQ0In0seyJuYW1lIjoidXJsIiwidHlwZSI6InN0cmluZyIsInZhbHVlIjoiZ2l0c3BhbS5zcGFtL3NwYW0vc3BhbSJ9XSwidGFza1NwZWMiOnsicGFyYW1zIjpbeyJuYW1lIjoiY29tbWl0IiwidHlwZSI6InN0cmluZyIsImRlc2NyaXB0aW9uIjoiVGhlIHZhbHVlIHRvIG9mIHRoZSBjb21taXQgcmVzdWx0LiJ9LHsibmFtZSI6InVybCIsInR5cGUiOiJzdHJpbmciLCJkZXNjcmlwdGlvbiI6IlRoZSB2YWx1ZSBvZiB0aGUgdXJsIHJlc3VsdC4ifSx7Im5hbWUiOiJjb21taXR0ZXItZGF0ZSIsInR5cGUiOiJzdHJpbmciLCJkZXNjcmlwdGlvbiI6IlRoZSB2YWx1ZSBvZiB0aGUgY29tbWl0dGVyLWRhdGUgcmVzdWx0LiJ9XSwiZGVzY3JpcHRpb24iOiJUaGlzIGlzIGEgZHVtbXkgdGFzayB0aGF0IGVtdWxhdGVzIGEgdGFzayB0aGF0IHBlcmZvcm1zIGEgZ2l0IGNsb25lLiBJdHMgc29sZSBwdXJwb3NlIGlzIHRvIGZhY2lsaXRhdGUgdGVzdGluZy4iLCJzdGVwcyI6W3sibmFtZSI6ImNsb25lIiwiaW1hZ2UiOiJyZWdpc3RyeS5hY2Nlc3MucmVkaGF0LmNvbS91Ymk5OmxhdGVzdCIsImVudiI6W3sibmFtZSI6IkNPTU1JVCIsInZhbHVlIjoiZjZhZWM2ODY4OTEzODAwMTMzZTJjNjFmYjMxODMyODZmZmQxNTUxYSJ9LHsibmFtZSI6IlVSTCIsInZhbHVlIjoiZ2l0c3BhbS5zcGFtL3NwYW0vc3BhbSJ9LHsibmFtZSI6IkNPTU1JVFRFUl9EQVRFIiwidmFsdWUiOiIxNjk3NTU5MDQ0In1dLCJyZXNvdXJjZXMiOnt9LCJzY3JpcHQiOiIjIS91c3IvYmluL2VudiBzaFxuc2V0IC1ldW8gcGlwZWZhaWxcblxuZWNobyAtbiBcIiR7Q09NTUlUfVwiIFx1MDAzZSBcIi90ZWt0b24vcmVzdWx0cy9jb21taXRcIlxuZWNobyAtbiBcIiR7VVJMfVwiIFx1MDAzZSBcIi90ZWt0b24vcmVzdWx0cy91cmxcIlxuZWNobyAtbiBcIiR7Q09NTUlUVEVSX0RBVEV9XCIgXHUwMDNlIFwiL3Rla3Rvbi9yZXN1bHRzL2NvbW1pdHRlci1kYXRlXCJcbiJ9XSwicmVzdWx0cyI6W3sibmFtZSI6ImNvbW1pdCIsInR5cGUiOiJzdHJpbmciLCJkZXNjcmlwdGlvbiI6IlRoZSBwcmVjaXNlIGNvbW1pdCBTSEEgdGhhdCB3YXMgZmV0Y2hlZCBieSB0aGlzIFRhc2suIn0seyJuYW1lIjoidXJsIiwidHlwZSI6InN0cmluZyIsImRlc2NyaXB0aW9uIjoiVGhlIHByZWNpc2UgVVJMIHRoYXQgd2FzIGZldGNoZWQgYnkgdGhpcyBUYXNrLiJ9LHsibmFtZSI6ImNvbW1pdHRlci1kYXRlIiwidHlwZSI6InN0cmluZyIsImRlc2NyaXB0aW9uIjoiVGhlIGVwb2NoIHRpbWVzdGFtcCBvZiB0aGUgY29tbWl0IHRoYXQgd2FzIGZldGNoZWQgYnkgdGhpcyBUYXNrLiJ9XX0sInByb3ZlbmFuY2UiOnsicmVmU291cmNlIjp7InVyaSI6ImdpdCtodHRwczovL2dpdGh1Yi5jb20vbGNhcnZhL2VjLXBvbGljaWVzLmdpdCIsImRpZ2VzdCI6eyJzaGExIjoiNzI3ZjhjYWU2OWZkZmJhZTdjZjhhNDRmZDVlMjA1NWFkOTU3M2ZiOSJ9LCJlbnRyeVBvaW50IjoiaW50ZWdyYXRpb24vdGFzay9tb2NrLWdpdC1jbG9uZS55YW1sIn0sImZlYXR1cmVGbGFncyI6eyJEaXNhYmxlQWZmaW5pdHlBc3Npc3RhbnQiOmZhbHNlLCJEaXNhYmxlQ3JlZHNJbml0IjpmYWxzZSwiUnVubmluZ0luRW52V2l0aEluamVjdGVkU2lkZWNhcnMiOnRydWUsIlJlcXVpcmVHaXRTU0hTZWNyZXRLbm93bkhvc3RzIjpmYWxzZSwiRW5hYmxlVGVrdG9uT0NJQnVuZGxlcyI6ZmFsc2UsIlNjb3BlV2hlbkV4cHJlc3Npb25zVG9UYXNrIjpmYWxzZSwiRW5hYmxlQVBJRmllbGRzIjoiYmV0YSIsIlNlbmRDbG91ZEV2ZW50c0ZvclJ1bnMiOmZhbHNlLCJBd2FpdFNpZGVjYXJSZWFkaW5lc3MiOnRydWUsIkVuZm9yY2VOb25mYWxzaWZpYWJpbGl0eSI6Im5vbmUiLCJWZXJpZmljYXRpb25Ob01hdGNoUG9saWN5IjoiaWdub3JlIiwiRW5hYmxlUHJvdmVuYW5jZUluU3RhdHVzIjp0cnVlLCJSZXN1bHRFeHRyYWN0aW9uTWV0aG9kIjoidGVybWluYXRpb24tbWVzc2FnZSIsIk1heFJlc3VsdFNpemUiOjQwOTYsIlNldFNlY3VyaXR5Q29udGV4dCI6ZmFsc2UsIkNvc2NoZWR1bGUiOiJ3b3Jrc3BhY2VzIn19fX0=",
+          "__decodedContent": {
+            "metadata": {
+              "name": "simple-build-run-e09d60fe56-git-clone",
+              "namespace": "default",
+              "uid": "8464c410-9ac8-457a-8e63-83cb0bd964f4",
+              "resourceVersion": "2031",
+              "generation": 1,
+              "creationTimestamp": "2023-10-17T16:10:45Z",
+              "labels": {
+                "app.kubernetes.io/managed-by": "tekton-pipelines",
+                "tekton.dev/memberOf": "tasks",
+                "tekton.dev/pipeline": "simple-build",
+                "tekton.dev/pipelineRun": "simple-build-run-e09d60fe56",
+                "tekton.dev/pipelineTask": "git-clone",
+                "tekton.dev/task": "mock-git-clone"
+              },
+              "annotations": {
+                "chains.tekton.dev/signed": "true",
+                "pipeline.tekton.dev/release": "e7b5e58"
+              },
+              "ownerReferences": [
+                {
+                  "apiVersion": "tekton.dev/v1",
+                  "kind": "PipelineRun",
+                  "name": "simple-build-run-e09d60fe56",
+                  "uid": "61302bbc-e8c6-4059-9692-92036c9c0691",
+                  "controller": true,
+                  "blockOwnerDeletion": true
+                }
+              ],
+              "finalizers": [
+                "chains.tekton.dev"
+              ],
+              "managedFields": [
+                {
+                  "manager": "controller",
+                  "operation": "Update",
+                  "apiVersion": "tekton.dev/v1",
+                  "time": "2023-10-17T16:10:45Z",
+                  "fieldsType": "FieldsV1",
+                  "fieldsV1": {
+                    "f:metadata": {
+                      "f:annotations": {
+                        ".": {},
+                        "f:pipeline.tekton.dev/release": {}
+                      },
+                      "f:labels": {
+                        ".": {},
+                        "f:tekton.dev/memberOf": {},
+                        "f:tekton.dev/pipeline": {},
+                        "f:tekton.dev/pipelineRun": {},
+                        "f:tekton.dev/pipelineTask": {},
+                        "f:tekton.dev/task": {}
+                      },
+                      "f:ownerReferences": {
+                        ".": {},
+                        "k:{\"uid\":\"61302bbc-e8c6-4059-9692-92036c9c0691\"}": {}
+                      }
+                    },
+                    "f:spec": {
+                      ".": {},
+                      "f:params": {},
+                      "f:serviceAccountName": {},
+                      "f:taskRef": {
+                        ".": {},
+                        "f:kind": {},
+                        "f:params": {},
+                        "f:resolver": {}
+                      }
+                    }
+                  }
+                },
+                {
+                  "manager": "controller",
+                  "operation": "Update",
+                  "apiVersion": "tekton.dev/v1",
+                  "time": "2023-10-17T16:10:49Z",
+                  "fieldsType": "FieldsV1",
+                  "fieldsV1": {
+                    "f:status": {
+                      "f:completionTime": {},
+                      "f:conditions": {},
+                      "f:podName": {},
+                      "f:provenance": {
+                        ".": {},
+                        "f:featureFlags": {
+                          ".": {},
+                          "f:AwaitSidecarReadiness": {},
+                          "f:Coschedule": {},
+                          "f:DisableAffinityAssistant": {},
+                          "f:DisableCredsInit": {},
+                          "f:EnableAPIFields": {},
+                          "f:EnableProvenanceInStatus": {},
+                          "f:EnableTektonOCIBundles": {},
+                          "f:EnforceNonfalsifiability": {},
+                          "f:MaxResultSize": {},
+                          "f:RequireGitSSHSecretKnownHosts": {},
+                          "f:ResultExtractionMethod": {},
+                          "f:RunningInEnvWithInjectedSidecars": {},
+                          "f:ScopeWhenExpressionsToTask": {},
+                          "f:SendCloudEventsForRuns": {},
+                          "f:SetSecurityContext": {},
+                          "f:VerificationNoMatchPolicy": {}
+                        },
+                        "f:refSource": {
+                          ".": {},
+                          "f:digest": {
+                            ".": {},
+                            "f:sha1": {}
+                          },
+                          "f:entryPoint": {},
+                          "f:uri": {}
+                        }
+                      },
+                      "f:results": {},
+                      "f:startTime": {},
+                      "f:steps": {},
+                      "f:taskSpec": {
+                        ".": {},
+                        "f:description": {},
+                        "f:params": {},
+                        "f:results": {},
+                        "f:steps": {}
+                      }
+                    }
+                  },
+                  "subresource": "status"
+                },
+                {
+                  "manager": "controller",
+                  "operation": "Update",
+                  "apiVersion": "tekton.dev/v1beta1",
+                  "time": "2023-10-17T16:10:50Z",
+                  "fieldsType": "FieldsV1",
+                  "fieldsV1": {
+                    "f:metadata": {
+                      "f:annotations": {
+                        "f:chains.tekton.dev/signed": {}
+                      },
+                      "f:finalizers": {
+                        ".": {},
+                        "v:\"chains.tekton.dev\"": {}
+                      }
+                    }
+                  }
+                }
+              ]
+            },
+            "spec": {
+              "params": [
+                {
+                  "name": "commit",
+                  "value": "f6aec6868913800133e2c61fb3183286ffd1551a"
+                },
+                {
+                  "name": "url",
+                  "value": "gitspam.spam/spam/spam"
+                },
+                {
+                  "name": "committer-date",
+                  "value": "1697559044"
+                }
+              ],
+              "serviceAccountName": "default",
+              "taskRef": {
+                "kind": "Task",
+                "resolver": "git",
+                "params": [
+                  {
+                    "name": "url",
+                    "value": "https://github.com/lcarva/ec-policies.git"
+                  },
+                  {
+                    "name": "revision",
+                    "value": "727f8cae69fdfbae7cf8a44fd5e2055ad9573fb9"
+                  },
+                  {
+                    "name": "pathInRepo",
+                    "value": "integration/task/mock-git-clone.yaml"
+                  }
+                ]
+              },
+              "timeout": "1h0m0s"
+            },
+            "status": {
+              "conditions": [
+                {
+                  "type": "Succeeded",
+                  "status": "True",
+                  "lastTransitionTime": "2023-10-17T16:10:49Z",
+                  "reason": "Succeeded",
+                  "message": "All Steps have completed executing"
+                }
+              ],
+              "podName": "simple-build-run-e09d60fe56-git-clone-pod",
+              "startTime": "2023-10-17T16:10:45Z",
+              "completionTime": "2023-10-17T16:10:49Z",
+              "steps": [
+                {
+                  "terminated": {
+                    "exitCode": 0,
+                    "reason": "Completed",
+                    "message": "[{\"key\":\"commit\",\"value\":\"f6aec6868913800133e2c61fb3183286ffd1551a\",\"type\":1},{\"key\":\"committer-date\",\"value\":\"1697559044\",\"type\":1},{\"key\":\"url\",\"value\":\"gitspam.spam/spam/spam\",\"type\":1}]",
+                    "startedAt": "2023-10-17T16:10:49Z",
+                    "finishedAt": "2023-10-17T16:10:49Z",
+                    "containerID": "containerd://ff3e76bd7c886bc1597420dd51738236237c4346fd74d62a710f4bafc7567af3"
+                  },
+                  "name": "clone",
+                  "container": "step-clone",
+                  "imageID": "registry.access.redhat.com/ubi9@sha256:20f695d2a91352d4eaa25107535126727b5945bff38ed36a3e59590f495046f0"
+                }
+              ],
+              "taskResults": [
+                {
+                  "name": "commit",
+                  "type": "string",
+                  "value": "f6aec6868913800133e2c61fb3183286ffd1551a"
+                },
+                {
+                  "name": "committer-date",
+                  "type": "string",
+                  "value": "1697559044"
+                },
+                {
+                  "name": "url",
+                  "type": "string",
+                  "value": "gitspam.spam/spam/spam"
+                }
+              ],
+              "taskSpec": {
+                "params": [
+                  {
+                    "name": "commit",
+                    "type": "string",
+                    "description": "The value to of the commit result."
+                  },
+                  {
+                    "name": "url",
+                    "type": "string",
+                    "description": "The value of the url result."
+                  },
+                  {
+                    "name": "committer-date",
+                    "type": "string",
+                    "description": "The value of the committer-date result."
+                  }
+                ],
+                "description": "This is a dummy task that emulates a task that performs a git clone. Its sole purpose is to facilitate testing.",
+                "steps": [
+                  {
+                    "name": "clone",
+                    "image": "registry.access.redhat.com/ubi9:latest",
+                    "env": [
+                      {
+                        "name": "COMMIT",
+                        "value": "f6aec6868913800133e2c61fb3183286ffd1551a"
+                      },
+                      {
+                        "name": "URL",
+                        "value": "gitspam.spam/spam/spam"
+                      },
+                      {
+                        "name": "COMMITTER_DATE",
+                        "value": "1697559044"
+                      }
+                    ],
+                    "resources": {},
+                    "script": "#!/usr/bin/env sh\nset -euo pipefail\n\necho -n \"${COMMIT}\" > \"/tekton/results/commit\"\necho -n \"${URL}\" > \"/tekton/results/url\"\necho -n \"${COMMITTER_DATE}\" > \"/tekton/results/committer-date\"\n"
+                  }
+                ],
+                "results": [
+                  {
+                    "name": "commit",
+                    "type": "string",
+                    "description": "The precise commit SHA that was fetched by this Task."
+                  },
+                  {
+                    "name": "url",
+                    "type": "string",
+                    "description": "The precise URL that was fetched by this Task."
+                  },
+                  {
+                    "name": "committer-date",
+                    "type": "string",
+                    "description": "The epoch timestamp of the commit that was fetched by this Task."
+                  }
+                ]
+              },
+              "provenance": {
+                "refSource": {
+                  "uri": "git+https://github.com/lcarva/ec-policies.git",
+                  "digest": {
+                    "sha1": "727f8cae69fdfbae7cf8a44fd5e2055ad9573fb9"
+                  },
+                  "entryPoint": "integration/task/mock-git-clone.yaml"
+                },
+                "featureFlags": {
+                  "DisableAffinityAssistant": false,
+                  "DisableCredsInit": false,
+                  "RunningInEnvWithInjectedSidecars": true,
+                  "RequireGitSSHSecretKnownHosts": false,
+                  "EnableTektonOCIBundles": false,
+                  "ScopeWhenExpressionsToTask": false,
+                  "EnableAPIFields": "beta",
+                  "SendCloudEventsForRuns": false,
+                  "AwaitSidecarReadiness": true,
+                  "EnforceNonfalsifiability": "none",
+                  "VerificationNoMatchPolicy": "ignore",
+                  "EnableProvenanceInStatus": true,
+                  "ResultExtractionMethod": "termination-message",
+                  "MaxResultSize": 4096,
+                  "SetSecurityContext": false,
+                  "Coschedule": "workspaces"
+                }
+              }
+            }
+          }
+        },
+        {
+          "uri": "oci://registry.access.redhat.com/ubi9",
+          "digest": {
+            "sha256": "20f695d2a91352d4eaa25107535126727b5945bff38ed36a3e59590f495046f0"
+          }
+        },
+        {
+          "name": "pipelineTask",
+          "content": "eyJtZXRhZGF0YSI6eyJuYW1lIjoic2ltcGxlLWJ1aWxkLXJ1bi1lMDlkNjBmZTU2LXNjYW4iLCJuYW1lc3BhY2UiOiJkZWZhdWx0IiwidWlkIjoiMDFjZDJhNjktNTk2Ny00MWVkLWEyN2UtZTczY2MwZmM2OWUzIiwicmVzb3VyY2VWZXJzaW9uIjoiMjA4NiIsImdlbmVyYXRpb24iOjEsImNyZWF0aW9uVGltZXN0YW1wIjoiMjAyMy0xMC0xN1QxNjoxMDo0OVoiLCJsYWJlbHMiOnsiYXBwLmt1YmVybmV0ZXMuaW8vbWFuYWdlZC1ieSI6InRla3Rvbi1waXBlbGluZXMiLCJ0ZWt0b24uZGV2L21lbWJlck9mIjoidGFza3MiLCJ0ZWt0b24uZGV2L3BpcGVsaW5lIjoic2ltcGxlLWJ1aWxkIiwidGVrdG9uLmRldi9waXBlbGluZVJ1biI6InNpbXBsZS1idWlsZC1ydW4tZTA5ZDYwZmU1NiIsInRla3Rvbi5kZXYvcGlwZWxpbmVUYXNrIjoic2NhbiJ9LCJhbm5vdGF0aW9ucyI6eyJjaGFpbnMudGVrdG9uLmRldi9zaWduZWQiOiJ0cnVlIiwicGlwZWxpbmUudGVrdG9uLmRldi9yZWxlYXNlIjoiZTdiNWU1OCJ9LCJvd25lclJlZmVyZW5jZXMiOlt7ImFwaVZlcnNpb24iOiJ0ZWt0b24uZGV2L3YxIiwia2luZCI6IlBpcGVsaW5lUnVuIiwibmFtZSI6InNpbXBsZS1idWlsZC1ydW4tZTA5ZDYwZmU1NiIsInVpZCI6IjYxMzAyYmJjLWU4YzYtNDA1OS05NjkyLTkyMDM2YzljMDY5MSIsImNvbnRyb2xsZXIiOnRydWUsImJsb2NrT3duZXJEZWxldGlvbiI6dHJ1ZX1dLCJmaW5hbGl6ZXJzIjpbImNoYWlucy50ZWt0b24uZGV2Il0sIm1hbmFnZWRGaWVsZHMiOlt7Im1hbmFnZXIiOiJjb250cm9sbGVyIiwib3BlcmF0aW9uIjoiVXBkYXRlIiwiYXBpVmVyc2lvbiI6InRla3Rvbi5kZXYvdjEiLCJ0aW1lIjoiMjAyMy0xMC0xN1QxNjoxMDo0OVoiLCJmaWVsZHNUeXBlIjoiRmllbGRzVjEiLCJmaWVsZHNWMSI6eyJmOm1ldGFkYXRhIjp7ImY6YW5ub3RhdGlvbnMiOnsiLiI6e30sImY6cGlwZWxpbmUudGVrdG9uLmRldi9yZWxlYXNlIjp7fX0sImY6bGFiZWxzIjp7Ii4iOnt9LCJmOnRla3Rvbi5kZXYvbWVtYmVyT2YiOnt9LCJmOnRla3Rvbi5kZXYvcGlwZWxpbmUiOnt9LCJmOnRla3Rvbi5kZXYvcGlwZWxpbmVSdW4iOnt9LCJmOnRla3Rvbi5kZXYvcGlwZWxpbmVUYXNrIjp7fX0sImY6b3duZXJSZWZlcmVuY2VzIjp7Ii4iOnt9LCJrOntcInVpZFwiOlwiNjEzMDJiYmMtZThjNi00MDU5LTk2OTItOTIwMzZjOWMwNjkxXCJ9Ijp7fX19LCJmOnNwZWMiOnsiLiI6e30sImY6cGFyYW1zIjp7fSwiZjpzZXJ2aWNlQWNjb3VudE5hbWUiOnt9LCJmOnRhc2tTcGVjIjp7Ii4iOnt9LCJmOmRlc2NyaXB0aW9uIjp7fSwiZjpwYXJhbXMiOnt9LCJmOnJlc3VsdHMiOnt9LCJmOnN0ZXBzIjp7fX19fX0seyJtYW5hZ2VyIjoiY29udHJvbGxlciIsIm9wZXJhdGlvbiI6IlVwZGF0ZSIsImFwaVZlcnNpb24iOiJ0ZWt0b24uZGV2L3YxIiwidGltZSI6IjIwMjMtMTAtMTdUMTY6MTA6NTNaIiwiZmllbGRzVHlwZSI6IkZpZWxkc1YxIiwiZmllbGRzVjEiOnsiZjpzdGF0dXMiOnsiZjpjb21wbGV0aW9uVGltZSI6e30sImY6Y29uZGl0aW9ucyI6e30sImY6cG9kTmFtZSI6e30sImY6cHJvdmVuYW5jZSI6eyIuIjp7fSwiZjpmZWF0dXJlRmxhZ3MiOnsiLiI6e30sImY6QXdhaXRTaWRlY2FyUmVhZGluZXNzIjp7fSwiZjpDb3NjaGVkdWxlIjp7fSwiZjpEaXNhYmxlQWZmaW5pdHlBc3Npc3RhbnQiOnt9LCJmOkRpc2FibGVDcmVkc0luaXQiOnt9LCJmOkVuYWJsZUFQSUZpZWxkcyI6e30sImY6RW5hYmxlUHJvdmVuYW5jZUluU3RhdHVzIjp7fSwiZjpFbmFibGVUZWt0b25PQ0lCdW5kbGVzIjp7fSwiZjpFbmZvcmNlTm9uZmFsc2lmaWFiaWxpdHkiOnt9LCJmOk1heFJlc3VsdFNpemUiOnt9LCJmOlJlcXVpcmVHaXRTU0hTZWNyZXRLbm93bkhvc3RzIjp7fSwiZjpSZXN1bHRFeHRyYWN0aW9uTWV0aG9kIjp7fSwiZjpSdW5uaW5nSW5FbnZXaXRoSW5qZWN0ZWRTaWRlY2FycyI6e30sImY6U2NvcGVXaGVuRXhwcmVzc2lvbnNUb1Rhc2siOnt9LCJmOlNlbmRDbG91ZEV2ZW50c0ZvclJ1bnMiOnt9LCJmOlNldFNlY3VyaXR5Q29udGV4dCI6e30sImY6VmVyaWZpY2F0aW9uTm9NYXRjaFBvbGljeSI6e319fSwiZjpyZXN1bHRzIjp7fSwiZjpzdGFydFRpbWUiOnt9LCJmOnN0ZXBzIjp7fSwiZjp0YXNrU3BlYyI6eyIuIjp7fSwiZjpkZXNjcmlwdGlvbiI6e30sImY6cGFyYW1zIjp7fSwiZjpyZXN1bHRzIjp7fSwiZjpzdGVwcyI6e319fX0sInN1YnJlc291cmNlIjoic3RhdHVzIn0seyJtYW5hZ2VyIjoiY29udHJvbGxlciIsIm9wZXJhdGlvbiI6IlVwZGF0ZSIsImFwaVZlcnNpb24iOiJ0ZWt0b24uZGV2L3YxYmV0YTEiLCJ0aW1lIjoiMjAyMy0xMC0xN1QxNjoxMDo1NFoiLCJmaWVsZHNUeXBlIjoiRmllbGRzVjEiLCJmaWVsZHNWMSI6eyJmOm1ldGFkYXRhIjp7ImY6YW5ub3RhdGlvbnMiOnsiZjpjaGFpbnMudGVrdG9uLmRldi9zaWduZWQiOnt9fSwiZjpmaW5hbGl6ZXJzIjp7Ii4iOnt9LCJ2OlwiY2hhaW5zLnRla3Rvbi5kZXZcIiI6e319fX19XX0sInNwZWMiOnsicGFyYW1zIjpbeyJuYW1lIjoiVEVTVF9PVVRQVVQiLCJ2YWx1ZSI6Im1pc3NpbmcifV0sInNlcnZpY2VBY2NvdW50TmFtZSI6ImRlZmF1bHQiLCJ0YXNrU3BlYyI6eyJwYXJhbXMiOlt7Im5hbWUiOiJURVNUX09VVFBVVCIsInR5cGUiOiJzdHJpbmciLCJkZXNjcmlwdGlvbiI6IlRoZSB2YWx1ZSB0byBvZiB0aGUgVEVTVF9PVVRQVVQgY29tbWl0IHJlc3VsdC4ifV0sImRlc2NyaXB0aW9uIjoiVGhpcyBpcyBhIGR1bW15IHRhc2sgdGhhdCBlbXVsYXRlcyBhIHRhc2sgdGhhdCBzY2FucyBzb3VyY2UgY29kZS4gSXRzIHNvbGUgcHVycG9zZSBpcyB0byBmYWNpbGl0YXRlIHRlc3RpbmcuIiwic3RlcHMiOlt7Im5hbWUiOiJzY2FuIiwiaW1hZ2UiOiJyZWdpc3RyeS5hY2Nlc3MucmVkaGF0LmNvbS91Ymk5OmxhdGVzdCIsImVudiI6W3sibmFtZSI6IlRFU1RfT1VUUFVUIiwidmFsdWUiOiJtaXNzaW5nIn1dLCJyZXNvdXJjZXMiOnt9LCJzY3JpcHQiOiIjIS91c3IvYmluL2VudiBzaFxuc2V0IC1ldW8gcGlwZWZhaWxcblxuZWNobyAtbiBcIiR7VEVTVF9PVVRQVVR9XCIgXHUwMDNlIFwiJChyZXN1bHRzLlRFU1RfT1VUUFVULnBhdGgpXCJcbiJ9XSwicmVzdWx0cyI6W3sibmFtZSI6IlRFU1RfT1VUUFVUIiwidHlwZSI6InN0cmluZyIsImRlc2NyaXB0aW9uIjoiVGhlIHN1bW1hcnkgc2Nhbm5lciBvdXRwdXQuIn1dfSwidGltZW91dCI6IjFoMG0wcyJ9LCJzdGF0dXMiOnsiY29uZGl0aW9ucyI6W3sidHlwZSI6IlN1Y2NlZWRlZCIsInN0YXR1cyI6IlRydWUiLCJsYXN0VHJhbnNpdGlvblRpbWUiOiIyMDIzLTEwLTE3VDE2OjEwOjUzWiIsInJlYXNvbiI6IlN1Y2NlZWRlZCIsIm1lc3NhZ2UiOiJBbGwgU3RlcHMgaGF2ZSBjb21wbGV0ZWQgZXhlY3V0aW5nIn1dLCJwb2ROYW1lIjoic2ltcGxlLWJ1aWxkLXJ1bi1lMDlkNjBmZTU2LXNjYW4tcG9kIiwic3RhcnRUaW1lIjoiMjAyMy0xMC0xN1QxNjoxMDo0OVoiLCJjb21wbGV0aW9uVGltZSI6IjIwMjMtMTAtMTdUMTY6MTA6NTNaIiwic3RlcHMiOlt7InRlcm1pbmF0ZWQiOnsiZXhpdENvZGUiOjAsInJlYXNvbiI6IkNvbXBsZXRlZCIsIm1lc3NhZ2UiOiJbe1wia2V5XCI6XCJURVNUX09VVFBVVFwiLFwidmFsdWVcIjpcIm1pc3NpbmdcIixcInR5cGVcIjoxfV0iLCJzdGFydGVkQXQiOiIyMDIzLTEwLTE3VDE2OjEwOjUzWiIsImZpbmlzaGVkQXQiOiIyMDIzLTEwLTE3VDE2OjEwOjUzWiIsImNvbnRhaW5lcklEIjoiY29udGFpbmVyZDovLzVjNGY1MDc2YTJiNmJkOGJiZmY0YzdhODI1YzllOWVjMTBlNDg4ZDk0NzU1MmI3YTIzZTA5NWM3Y2QyZDFjZmYifSwibmFtZSI6InNjYW4iLCJjb250YWluZXIiOiJzdGVwLXNjYW4iLCJpbWFnZUlEIjoicmVnaXN0cnkuYWNjZXNzLnJlZGhhdC5jb20vdWJpOUBzaGEyNTY6MjBmNjk1ZDJhOTEzNTJkNGVhYTI1MTA3NTM1MTI2NzI3YjU5NDViZmYzOGVkMzZhM2U1OTU5MGY0OTUwNDZmMCJ9XSwidGFza1Jlc3VsdHMiOlt7Im5hbWUiOiJURVNUX09VVFBVVCIsInR5cGUiOiJzdHJpbmciLCJ2YWx1ZSI6Im1pc3NpbmcifV0sInRhc2tTcGVjIjp7InBhcmFtcyI6W3sibmFtZSI6IlRFU1RfT1VUUFVUIiwidHlwZSI6InN0cmluZyIsImRlc2NyaXB0aW9uIjoiVGhlIHZhbHVlIHRvIG9mIHRoZSBURVNUX09VVFBVVCBjb21taXQgcmVzdWx0LiJ9XSwiZGVzY3JpcHRpb24iOiJUaGlzIGlzIGEgZHVtbXkgdGFzayB0aGF0IGVtdWxhdGVzIGEgdGFzayB0aGF0IHNjYW5zIHNvdXJjZSBjb2RlLiBJdHMgc29sZSBwdXJwb3NlIGlzIHRvIGZhY2lsaXRhdGUgdGVzdGluZy4iLCJzdGVwcyI6W3sibmFtZSI6InNjYW4iLCJpbWFnZSI6InJlZ2lzdHJ5LmFjY2Vzcy5yZWRoYXQuY29tL3ViaTk6bGF0ZXN0IiwiZW52IjpbeyJuYW1lIjoiVEVTVF9PVVRQVVQiLCJ2YWx1ZSI6Im1pc3NpbmcifV0sInJlc291cmNlcyI6e30sInNjcmlwdCI6IiMhL3Vzci9iaW4vZW52IHNoXG5zZXQgLWV1byBwaXBlZmFpbFxuXG5lY2hvIC1uIFwiJHtURVNUX09VVFBVVH1cIiBcdTAwM2UgXCIvdGVrdG9uL3Jlc3VsdHMvVEVTVF9PVVRQVVRcIlxuIn1dLCJyZXN1bHRzIjpbeyJuYW1lIjoiVEVTVF9PVVRQVVQiLCJ0eXBlIjoic3RyaW5nIiwiZGVzY3JpcHRpb24iOiJUaGUgc3VtbWFyeSBzY2FubmVyIG91dHB1dC4ifV19LCJwcm92ZW5hbmNlIjp7ImZlYXR1cmVGbGFncyI6eyJEaXNhYmxlQWZmaW5pdHlBc3Npc3RhbnQiOmZhbHNlLCJEaXNhYmxlQ3JlZHNJbml0IjpmYWxzZSwiUnVubmluZ0luRW52V2l0aEluamVjdGVkU2lkZWNhcnMiOnRydWUsIlJlcXVpcmVHaXRTU0hTZWNyZXRLbm93bkhvc3RzIjpmYWxzZSwiRW5hYmxlVGVrdG9uT0NJQnVuZGxlcyI6ZmFsc2UsIlNjb3BlV2hlbkV4cHJlc3Npb25zVG9UYXNrIjpmYWxzZSwiRW5hYmxlQVBJRmllbGRzIjoiYmV0YSIsIlNlbmRDbG91ZEV2ZW50c0ZvclJ1bnMiOmZhbHNlLCJBd2FpdFNpZGVjYXJSZWFkaW5lc3MiOnRydWUsIkVuZm9yY2VOb25mYWxzaWZpYWJpbGl0eSI6Im5vbmUiLCJWZXJpZmljYXRpb25Ob01hdGNoUG9saWN5IjoiaWdub3JlIiwiRW5hYmxlUHJvdmVuYW5jZUluU3RhdHVzIjp0cnVlLCJSZXN1bHRFeHRyYWN0aW9uTWV0aG9kIjoidGVybWluYXRpb24tbWVzc2FnZSIsIk1heFJlc3VsdFNpemUiOjQwOTYsIlNldFNlY3VyaXR5Q29udGV4dCI6ZmFsc2UsIkNvc2NoZWR1bGUiOiJ3b3Jrc3BhY2VzIn19fX0=",
+          "__decodedContent": {
+            "metadata": {
+              "name": "simple-build-run-e09d60fe56-scan",
+              "namespace": "default",
+              "uid": "01cd2a69-5967-41ed-a27e-e73cc0fc69e3",
+              "resourceVersion": "2086",
+              "generation": 1,
+              "creationTimestamp": "2023-10-17T16:10:49Z",
+              "labels": {
+                "app.kubernetes.io/managed-by": "tekton-pipelines",
+                "tekton.dev/memberOf": "tasks",
+                "tekton.dev/pipeline": "simple-build",
+                "tekton.dev/pipelineRun": "simple-build-run-e09d60fe56",
+                "tekton.dev/pipelineTask": "scan"
+              },
+              "annotations": {
+                "chains.tekton.dev/signed": "true",
+                "pipeline.tekton.dev/release": "e7b5e58"
+              },
+              "ownerReferences": [
+                {
+                  "apiVersion": "tekton.dev/v1",
+                  "kind": "PipelineRun",
+                  "name": "simple-build-run-e09d60fe56",
+                  "uid": "61302bbc-e8c6-4059-9692-92036c9c0691",
+                  "controller": true,
+                  "blockOwnerDeletion": true
+                }
+              ],
+              "finalizers": [
+                "chains.tekton.dev"
+              ],
+              "managedFields": [
+                {
+                  "manager": "controller",
+                  "operation": "Update",
+                  "apiVersion": "tekton.dev/v1",
+                  "time": "2023-10-17T16:10:49Z",
+                  "fieldsType": "FieldsV1",
+                  "fieldsV1": {
+                    "f:metadata": {
+                      "f:annotations": {
+                        ".": {},
+                        "f:pipeline.tekton.dev/release": {}
+                      },
+                      "f:labels": {
+                        ".": {},
+                        "f:tekton.dev/memberOf": {},
+                        "f:tekton.dev/pipeline": {},
+                        "f:tekton.dev/pipelineRun": {},
+                        "f:tekton.dev/pipelineTask": {}
+                      },
+                      "f:ownerReferences": {
+                        ".": {},
+                        "k:{\"uid\":\"61302bbc-e8c6-4059-9692-92036c9c0691\"}": {}
+                      }
+                    },
+                    "f:spec": {
+                      ".": {},
+                      "f:params": {},
+                      "f:serviceAccountName": {},
+                      "f:taskSpec": {
+                        ".": {},
+                        "f:description": {},
+                        "f:params": {},
+                        "f:results": {},
+                        "f:steps": {}
+                      }
+                    }
+                  }
+                },
+                {
+                  "manager": "controller",
+                  "operation": "Update",
+                  "apiVersion": "tekton.dev/v1",
+                  "time": "2023-10-17T16:10:53Z",
+                  "fieldsType": "FieldsV1",
+                  "fieldsV1": {
+                    "f:status": {
+                      "f:completionTime": {},
+                      "f:conditions": {},
+                      "f:podName": {},
+                      "f:provenance": {
+                        ".": {},
+                        "f:featureFlags": {
+                          ".": {},
+                          "f:AwaitSidecarReadiness": {},
+                          "f:Coschedule": {},
+                          "f:DisableAffinityAssistant": {},
+                          "f:DisableCredsInit": {},
+                          "f:EnableAPIFields": {},
+                          "f:EnableProvenanceInStatus": {},
+                          "f:EnableTektonOCIBundles": {},
+                          "f:EnforceNonfalsifiability": {},
+                          "f:MaxResultSize": {},
+                          "f:RequireGitSSHSecretKnownHosts": {},
+                          "f:ResultExtractionMethod": {},
+                          "f:RunningInEnvWithInjectedSidecars": {},
+                          "f:ScopeWhenExpressionsToTask": {},
+                          "f:SendCloudEventsForRuns": {},
+                          "f:SetSecurityContext": {},
+                          "f:VerificationNoMatchPolicy": {}
+                        }
+                      },
+                      "f:results": {},
+                      "f:startTime": {},
+                      "f:steps": {},
+                      "f:taskSpec": {
+                        ".": {},
+                        "f:description": {},
+                        "f:params": {},
+                        "f:results": {},
+                        "f:steps": {}
+                      }
+                    }
+                  },
+                  "subresource": "status"
+                },
+                {
+                  "manager": "controller",
+                  "operation": "Update",
+                  "apiVersion": "tekton.dev/v1beta1",
+                  "time": "2023-10-17T16:10:54Z",
+                  "fieldsType": "FieldsV1",
+                  "fieldsV1": {
+                    "f:metadata": {
+                      "f:annotations": {
+                        "f:chains.tekton.dev/signed": {}
+                      },
+                      "f:finalizers": {
+                        ".": {},
+                        "v:\"chains.tekton.dev\"": {}
+                      }
+                    }
+                  }
+                }
+              ]
+            },
+            "spec": {
+              "params": [
+                {
+                  "name": "TEST_OUTPUT",
+                  "value": "missing"
+                }
+              ],
+              "serviceAccountName": "default",
+              "taskSpec": {
+                "params": [
+                  {
+                    "name": "TEST_OUTPUT",
+                    "type": "string",
+                    "description": "The value to of the TEST_OUTPUT commit result."
+                  }
+                ],
+                "description": "This is a dummy task that emulates a task that scans source code. Its sole purpose is to facilitate testing.",
+                "steps": [
+                  {
+                    "name": "scan",
+                    "image": "registry.access.redhat.com/ubi9:latest",
+                    "env": [
+                      {
+                        "name": "TEST_OUTPUT",
+                        "value": "missing"
+                      }
+                    ],
+                    "resources": {},
+                    "script": "#!/usr/bin/env sh\nset -euo pipefail\n\necho -n \"${TEST_OUTPUT}\" > \"$(results.TEST_OUTPUT.path)\"\n"
+                  }
+                ],
+                "results": [
+                  {
+                    "name": "TEST_OUTPUT",
+                    "type": "string",
+                    "description": "The summary scanner output."
+                  }
+                ]
+              },
+              "timeout": "1h0m0s"
+            },
+            "status": {
+              "conditions": [
+                {
+                  "type": "Succeeded",
+                  "status": "True",
+                  "lastTransitionTime": "2023-10-17T16:10:53Z",
+                  "reason": "Succeeded",
+                  "message": "All Steps have completed executing"
+                }
+              ],
+              "podName": "simple-build-run-e09d60fe56-scan-pod",
+              "startTime": "2023-10-17T16:10:49Z",
+              "completionTime": "2023-10-17T16:10:53Z",
+              "steps": [
+                {
+                  "terminated": {
+                    "exitCode": 0,
+                    "reason": "Completed",
+                    "message": "[{\"key\":\"TEST_OUTPUT\",\"value\":\"missing\",\"type\":1}]",
+                    "startedAt": "2023-10-17T16:10:53Z",
+                    "finishedAt": "2023-10-17T16:10:53Z",
+                    "containerID": "containerd://5c4f5076a2b6bd8bbff4c7a825c9e9ec10e488d947552b7a23e095c7cd2d1cff"
+                  },
+                  "name": "scan",
+                  "container": "step-scan",
+                  "imageID": "registry.access.redhat.com/ubi9@sha256:20f695d2a91352d4eaa25107535126727b5945bff38ed36a3e59590f495046f0"
+                }
+              ],
+              "taskResults": [
+                {
+                  "name": "TEST_OUTPUT",
+                  "type": "string",
+                  "value": "missing"
+                }
+              ],
+              "taskSpec": {
+                "params": [
+                  {
+                    "name": "TEST_OUTPUT",
+                    "type": "string",
+                    "description": "The value to of the TEST_OUTPUT commit result."
+                  }
+                ],
+                "description": "This is a dummy task that emulates a task that scans source code. Its sole purpose is to facilitate testing.",
+                "steps": [
+                  {
+                    "name": "scan",
+                    "image": "registry.access.redhat.com/ubi9:latest",
+                    "env": [
+                      {
+                        "name": "TEST_OUTPUT",
+                        "value": "missing"
+                      }
+                    ],
+                    "resources": {},
+                    "script": "#!/usr/bin/env sh\nset -euo pipefail\n\necho -n \"${TEST_OUTPUT}\" > \"/tekton/results/TEST_OUTPUT\"\n"
+                  }
+                ],
+                "results": [
+                  {
+                    "name": "TEST_OUTPUT",
+                    "type": "string",
+                    "description": "The summary scanner output."
+                  }
+                ]
+              },
+              "provenance": {
+                "featureFlags": {
+                  "DisableAffinityAssistant": false,
+                  "DisableCredsInit": false,
+                  "RunningInEnvWithInjectedSidecars": true,
+                  "RequireGitSSHSecretKnownHosts": false,
+                  "EnableTektonOCIBundles": false,
+                  "ScopeWhenExpressionsToTask": false,
+                  "EnableAPIFields": "beta",
+                  "SendCloudEventsForRuns": false,
+                  "AwaitSidecarReadiness": true,
+                  "EnforceNonfalsifiability": "none",
+                  "VerificationNoMatchPolicy": "ignore",
+                  "EnableProvenanceInStatus": true,
+                  "ResultExtractionMethod": "termination-message",
+                  "MaxResultSize": 4096,
+                  "SetSecurityContext": false,
+                  "Coschedule": "workspaces"
+                }
+              }
+            }
+          }
+        },
+        {
+          "uri": "quay.io/lucarval/test-policies-chains",
+          "digest": {
+            "sha256": "c6ea74a4f8003179532dc2d74a51ef170be078acd4821fba15856d83eaa2d67a"
+          },
+          "name": "pipelineTask",
+          "content": "eyJtZXRhZGF0YSI6eyJuYW1lIjoic2ltcGxlLWJ1aWxkLXJ1bi1lMDlkNjBmZTU2LWJ1aWxkIiwibmFtZXNwYWNlIjoiZGVmYXVsdCIsInVpZCI6IjFlNjdiOWY4LWI4NmEtNDhlZS04OTQ1LTZlYmFjMWE2YzliYiIsInJlc291cmNlVmVyc2lvbiI6IjIxMzEiLCJnZW5lcmF0aW9uIjoxLCJjcmVhdGlvblRpbWVzdGFtcCI6IjIwMjMtMTAtMTdUMTY6MTA6NTNaIiwibGFiZWxzIjp7ImFwcC5rdWJlcm5ldGVzLmlvL21hbmFnZWQtYnkiOiJ0ZWt0b24tcGlwZWxpbmVzIiwidGVrdG9uLmRldi9tZW1iZXJPZiI6InRhc2tzIiwidGVrdG9uLmRldi9waXBlbGluZSI6InNpbXBsZS1idWlsZCIsInRla3Rvbi5kZXYvcGlwZWxpbmVSdW4iOiJzaW1wbGUtYnVpbGQtcnVuLWUwOWQ2MGZlNTYiLCJ0ZWt0b24uZGV2L3BpcGVsaW5lVGFzayI6ImJ1aWxkIiwidGVrdG9uLmRldi90YXNrIjoibW9jay1idWlsZCJ9LCJhbm5vdGF0aW9ucyI6eyJjaGFpbnMudGVrdG9uLmRldi9zaWduZWQiOiJ0cnVlIiwicGlwZWxpbmUudGVrdG9uLmRldi9yZWxlYXNlIjoiZTdiNWU1OCJ9LCJvd25lclJlZmVyZW5jZXMiOlt7ImFwaVZlcnNpb24iOiJ0ZWt0b24uZGV2L3YxIiwia2luZCI6IlBpcGVsaW5lUnVuIiwibmFtZSI6InNpbXBsZS1idWlsZC1ydW4tZTA5ZDYwZmU1NiIsInVpZCI6IjYxMzAyYmJjLWU4YzYtNDA1OS05NjkyLTkyMDM2YzljMDY5MSIsImNvbnRyb2xsZXIiOnRydWUsImJsb2NrT3duZXJEZWxldGlvbiI6dHJ1ZX1dLCJmaW5hbGl6ZXJzIjpbImNoYWlucy50ZWt0b24uZGV2Il0sIm1hbmFnZWRGaWVsZHMiOlt7Im1hbmFnZXIiOiJjb250cm9sbGVyIiwib3BlcmF0aW9uIjoiVXBkYXRlIiwiYXBpVmVyc2lvbiI6InRla3Rvbi5kZXYvdjEiLCJ0aW1lIjoiMjAyMy0xMC0xN1QxNjoxMDo1M1oiLCJmaWVsZHNUeXBlIjoiRmllbGRzVjEiLCJmaWVsZHNWMSI6eyJmOm1ldGFkYXRhIjp7ImY6YW5ub3RhdGlvbnMiOnsiLiI6e30sImY6cGlwZWxpbmUudGVrdG9uLmRldi9yZWxlYXNlIjp7fX0sImY6bGFiZWxzIjp7Ii4iOnt9LCJmOnRla3Rvbi5kZXYvbWVtYmVyT2YiOnt9LCJmOnRla3Rvbi5kZXYvcGlwZWxpbmUiOnt9LCJmOnRla3Rvbi5kZXYvcGlwZWxpbmVSdW4iOnt9LCJmOnRla3Rvbi5kZXYvcGlwZWxpbmVUYXNrIjp7fSwiZjp0ZWt0b24uZGV2L3Rhc2siOnt9fSwiZjpvd25lclJlZmVyZW5jZXMiOnsiLiI6e30sIms6e1widWlkXCI6XCI2MTMwMmJiYy1lOGM2LTQwNTktOTY5Mi05MjAzNmM5YzA2OTFcIn0iOnt9fX0sImY6c3BlYyI6eyIuIjp7fSwiZjpwYXJhbXMiOnt9LCJmOnNlcnZpY2VBY2NvdW50TmFtZSI6e30sImY6dGFza1JlZiI6eyIuIjp7fSwiZjpraW5kIjp7fSwiZjpwYXJhbXMiOnt9LCJmOnJlc29sdmVyIjp7fX19fX0seyJtYW5hZ2VyIjoiY29udHJvbGxlciIsIm9wZXJhdGlvbiI6IlVwZGF0ZSIsImFwaVZlcnNpb24iOiJ0ZWt0b24uZGV2L3YxIiwidGltZSI6IjIwMjMtMTAtMTdUMTY6MTA6NTdaIiwiZmllbGRzVHlwZSI6IkZpZWxkc1YxIiwiZmllbGRzVjEiOnsiZjpzdGF0dXMiOnsiZjpjb21wbGV0aW9uVGltZSI6e30sImY6Y29uZGl0aW9ucyI6e30sImY6cG9kTmFtZSI6e30sImY6cHJvdmVuYW5jZSI6eyIuIjp7fSwiZjpmZWF0dXJlRmxhZ3MiOnsiLiI6e30sImY6QXdhaXRTaWRlY2FyUmVhZGluZXNzIjp7fSwiZjpDb3NjaGVkdWxlIjp7fSwiZjpEaXNhYmxlQWZmaW5pdHlBc3Npc3RhbnQiOnt9LCJmOkRpc2FibGVDcmVkc0luaXQiOnt9LCJmOkVuYWJsZUFQSUZpZWxkcyI6e30sImY6RW5hYmxlUHJvdmVuYW5jZUluU3RhdHVzIjp7fSwiZjpFbmFibGVUZWt0b25PQ0lCdW5kbGVzIjp7fSwiZjpFbmZvcmNlTm9uZmFsc2lmaWFiaWxpdHkiOnt9LCJmOk1heFJlc3VsdFNpemUiOnt9LCJmOlJlcXVpcmVHaXRTU0hTZWNyZXRLbm93bkhvc3RzIjp7fSwiZjpSZXN1bHRFeHRyYWN0aW9uTWV0aG9kIjp7fSwiZjpSdW5uaW5nSW5FbnZXaXRoSW5qZWN0ZWRTaWRlY2FycyI6e30sImY6U2NvcGVXaGVuRXhwcmVzc2lvbnNUb1Rhc2siOnt9LCJmOlNlbmRDbG91ZEV2ZW50c0ZvclJ1bnMiOnt9LCJmOlNldFNlY3VyaXR5Q29udGV4dCI6e30sImY6VmVyaWZpY2F0aW9uTm9NYXRjaFBvbGljeSI6e319LCJmOnJlZlNvdXJjZSI6eyIuIjp7fSwiZjpkaWdlc3QiOnsiLiI6e30sImY6c2hhMjU2Ijp7fX0sImY6ZW50cnlQb2ludCI6e30sImY6dXJpIjp7fX19LCJmOnJlc3VsdHMiOnt9LCJmOnN0YXJ0VGltZSI6e30sImY6c3RlcHMiOnt9LCJmOnRhc2tTcGVjIjp7Ii4iOnt9LCJmOmRlc2NyaXB0aW9uIjp7fSwiZjpwYXJhbXMiOnt9LCJmOnJlc3VsdHMiOnt9LCJmOnN0ZXBzIjp7fX19fSwic3VicmVzb3VyY2UiOiJzdGF0dXMifSx7Im1hbmFnZXIiOiJjb250cm9sbGVyIiwib3BlcmF0aW9uIjoiVXBkYXRlIiwiYXBpVmVyc2lvbiI6InRla3Rvbi5kZXYvdjFiZXRhMSIsInRpbWUiOiIyMDIzLTEwLTE3VDE2OjExOjAwWiIsImZpZWxkc1R5cGUiOiJGaWVsZHNWMSIsImZpZWxkc1YxIjp7ImY6bWV0YWRhdGEiOnsiZjphbm5vdGF0aW9ucyI6eyJmOmNoYWlucy50ZWt0b24uZGV2L3NpZ25lZCI6e319LCJmOmZpbmFsaXplcnMiOnsiLiI6e30sInY6XCJjaGFpbnMudGVrdG9uLmRldlwiIjp7fX19fX1dfSwic3BlYyI6eyJwYXJhbXMiOlt7Im5hbWUiOiJJTUFHRV9VUkwiLCJ2YWx1ZSI6InF1YXkuaW8vbHVjYXJ2YWwvdGVzdC1wb2xpY2llcy1jaGFpbnMifSx7Im5hbWUiOiJJTUFHRV9ESUdFU1QiLCJ2YWx1ZSI6InNoYTI1NjpmNjEzNWJhNjQwMzFkZmY4NWMwYTk3NzE3NzZhZDAzMTM1ZmVjYWQ3NWY1NzJjYjEzOTE3YmQxMzlmOGMzNzdjIn1dLCJzZXJ2aWNlQWNjb3VudE5hbWUiOiJkZWZhdWx0IiwidGFza1JlZiI6eyJraW5kIjoiVGFzayIsInJlc29sdmVyIjoiYnVuZGxlcyIsInBhcmFtcyI6W3sibmFtZSI6ImJ1bmRsZSIsInZhbHVlIjoicXVheS5pby9sdWNhcnZhbC90ZXN0LXBvbGljaWVzLWNoYWluc0BzaGEyNTY6YzZlYTc0YTRmODAwMzE3OTUzMmRjMmQ3NGE1MWVmMTcwYmUwNzhhY2Q0ODIxZmJhMTU4NTZkODNlYWEyZDY3YSJ9LHsibmFtZSI6Im5hbWUiLCJ2YWx1ZSI6Im1vY2stYnVpbGQifSx7Im5hbWUiOiJraW5kIiwidmFsdWUiOiJ0YXNrIn1dfSwidGltZW91dCI6IjFoMG0wcyJ9LCJzdGF0dXMiOnsiY29uZGl0aW9ucyI6W3sidHlwZSI6IlN1Y2NlZWRlZCIsInN0YXR1cyI6IlRydWUiLCJsYXN0VHJhbnNpdGlvblRpbWUiOiIyMDIzLTEwLTE3VDE2OjEwOjU3WiIsInJlYXNvbiI6IlN1Y2NlZWRlZCIsIm1lc3NhZ2UiOiJBbGwgU3RlcHMgaGF2ZSBjb21wbGV0ZWQgZXhlY3V0aW5nIn1dLCJwb2ROYW1lIjoic2ltcGxlLWJ1aWxkLXJ1bi1lMDlkNjBmZTU2LWJ1aWxkLXBvZCIsInN0YXJ0VGltZSI6IjIwMjMtMTAtMTdUMTY6MTA6NTNaIiwiY29tcGxldGlvblRpbWUiOiIyMDIzLTEwLTE3VDE2OjEwOjU3WiIsInN0ZXBzIjpbeyJ0ZXJtaW5hdGVkIjp7ImV4aXRDb2RlIjowLCJyZWFzb24iOiJDb21wbGV0ZWQiLCJtZXNzYWdlIjoiW3tcImtleVwiOlwiSU1BR0VfRElHRVNUXCIsXCJ2YWx1ZVwiOlwic2hhMjU2OmY2MTM1YmE2NDAzMWRmZjg1YzBhOTc3MTc3NmFkMDMxMzVmZWNhZDc1ZjU3MmNiMTM5MTdiZDEzOWY4YzM3N2NcIixcInR5cGVcIjoxfSx7XCJrZXlcIjpcIklNQUdFX1VSTFwiLFwidmFsdWVcIjpcInF1YXkuaW8vbHVjYXJ2YWwvdGVzdC1wb2xpY2llcy1jaGFpbnNcIixcInR5cGVcIjoxfV0iLCJzdGFydGVkQXQiOiIyMDIzLTEwLTE3VDE2OjEwOjU3WiIsImZpbmlzaGVkQXQiOiIyMDIzLTEwLTE3VDE2OjEwOjU3WiIsImNvbnRhaW5lcklEIjoiY29udGFpbmVyZDovL2YzMWViZTE2YWEwNzE0YjQ3M2Q5NWM4ZDczMTRjNThkMWMzZjgzNTNmMzc0MjhhNWM3Y2ZjZjkzMWRmYzYyNTkifSwibmFtZSI6ImJ1aWxkLWFuZC1wdXNoIiwiY29udGFpbmVyIjoic3RlcC1idWlsZC1hbmQtcHVzaCIsImltYWdlSUQiOiJyZWdpc3RyeS5hY2Nlc3MucmVkaGF0LmNvbS91Ymk5QHNoYTI1NjoyMGY2OTVkMmE5MTM1MmQ0ZWFhMjUxMDc1MzUxMjY3MjdiNTk0NWJmZjM4ZWQzNmEzZTU5NTkwZjQ5NTA0NmYwIn1dLCJ0YXNrUmVzdWx0cyI6W3sibmFtZSI6IklNQUdFX0RJR0VTVCIsInR5cGUiOiJzdHJpbmciLCJ2YWx1ZSI6InNoYTI1NjpmNjEzNWJhNjQwMzFkZmY4NWMwYTk3NzE3NzZhZDAzMTM1ZmVjYWQ3NWY1NzJjYjEzOTE3YmQxMzlmOGMzNzdjIn0seyJuYW1lIjoiSU1BR0VfVVJMIiwidHlwZSI6InN0cmluZyIsInZhbHVlIjoicXVheS5pby9sdWNhcnZhbC90ZXN0LXBvbGljaWVzLWNoYWlucyJ9XSwidGFza1NwZWMiOnsicGFyYW1zIjpbeyJuYW1lIjoiSU1BR0VfVVJMIiwidHlwZSI6InN0cmluZyIsImRlc2NyaXB0aW9uIjoiVGhlIHZhbHVlIHRvIG9mIHRoZSBJTUFHRV9VUkwgY29tbWl0IHJlc3VsdC4ifSx7Im5hbWUiOiJJTUFHRV9ESUdFU1QiLCJ0eXBlIjoic3RyaW5nIiwiZGVzY3JpcHRpb24iOiJUaGUgdmFsdWUgb2YgdGhlIElNQUdFX0RJR0VTVCByZXN1bHQuIn1dLCJkZXNjcmlwdGlvbiI6IlRoaXMgaXMgYSBkdW1teSB0YXNrIHRoYXQgZW11bGF0ZXMgYSB0YXNrIHRoYXQgcGVyZm9ybXMgY29udGFpbmVyIGJ1aWxkIGFuZCBwdXNoLiBJdHMgc29sZSBwdXJwb3NlIGlzIHRvIGZhY2lsaXRhdGUgdGVzdGluZy4iLCJzdGVwcyI6W3sibmFtZSI6ImJ1aWxkLWFuZC1wdXNoIiwiaW1hZ2UiOiJyZWdpc3RyeS5hY2Nlc3MucmVkaGF0LmNvbS91Ymk5OmxhdGVzdCIsImVudiI6W3sibmFtZSI6IklNQUdFX1VSTCIsInZhbHVlIjoicXVheS5pby9sdWNhcnZhbC90ZXN0LXBvbGljaWVzLWNoYWlucyJ9LHsibmFtZSI6IklNQUdFX0RJR0VTVCIsInZhbHVlIjoic2hhMjU2OmY2MTM1YmE2NDAzMWRmZjg1YzBhOTc3MTc3NmFkMDMxMzVmZWNhZDc1ZjU3MmNiMTM5MTdiZDEzOWY4YzM3N2MifV0sInJlc291cmNlcyI6e30sInNjcmlwdCI6IiMhL3Vzci9iaW4vZW52IHNoXG5zZXQgLWV1byBwaXBlZmFpbFxuXG5lY2hvIC1uIFwiJHtJTUFHRV9VUkx9XCIgXHUwMDNlIFwiL3Rla3Rvbi9yZXN1bHRzL0lNQUdFX1VSTFwiXG5lY2hvIC1uIFwiJHtJTUFHRV9ESUdFU1R9XCIgXHUwMDNlIFwiL3Rla3Rvbi9yZXN1bHRzL0lNQUdFX0RJR0VTVFwiXG4ifV0sInJlc3VsdHMiOlt7Im5hbWUiOiJJTUFHRV9VUkwiLCJ0eXBlIjoic3RyaW5nIiwiZGVzY3JpcHRpb24iOiJJbWFnZSByZXBvc2l0b3J5IHdoZXJlIHRoZSBidWlsdCBpbWFnZSB3b3VsZCBiZSBwdXNoZWQgdG8uIn0seyJuYW1lIjoiSU1BR0VfRElHRVNUIiwidHlwZSI6InN0cmluZyIsImRlc2NyaXB0aW9uIjoiRGlnZXN0IG9mIHRoZSBpbWFnZSBqdXN0IGJ1aWx0LiJ9XX0sInByb3ZlbmFuY2UiOnsicmVmU291cmNlIjp7InVyaSI6InF1YXkuaW8vbHVjYXJ2YWwvdGVzdC1wb2xpY2llcy1jaGFpbnMiLCJkaWdlc3QiOnsic2hhMjU2IjoiYzZlYTc0YTRmODAwMzE3OTUzMmRjMmQ3NGE1MWVmMTcwYmUwNzhhY2Q0ODIxZmJhMTU4NTZkODNlYWEyZDY3YSJ9LCJlbnRyeVBvaW50IjoibW9jay1idWlsZCJ9LCJmZWF0dXJlRmxhZ3MiOnsiRGlzYWJsZUFmZmluaXR5QXNzaXN0YW50IjpmYWxzZSwiRGlzYWJsZUNyZWRzSW5pdCI6ZmFsc2UsIlJ1bm5pbmdJbkVudldpdGhJbmplY3RlZFNpZGVjYXJzIjp0cnVlLCJSZXF1aXJlR2l0U1NIU2VjcmV0S25vd25Ib3N0cyI6ZmFsc2UsIkVuYWJsZVRla3Rvbk9DSUJ1bmRsZXMiOmZhbHNlLCJTY29wZVdoZW5FeHByZXNzaW9uc1RvVGFzayI6ZmFsc2UsIkVuYWJsZUFQSUZpZWxkcyI6ImJldGEiLCJTZW5kQ2xvdWRFdmVudHNGb3JSdW5zIjpmYWxzZSwiQXdhaXRTaWRlY2FyUmVhZGluZXNzIjp0cnVlLCJFbmZvcmNlTm9uZmFsc2lmaWFiaWxpdHkiOiJub25lIiwiVmVyaWZpY2F0aW9uTm9NYXRjaFBvbGljeSI6Imlnbm9yZSIsIkVuYWJsZVByb3ZlbmFuY2VJblN0YXR1cyI6dHJ1ZSwiUmVzdWx0RXh0cmFjdGlvbk1ldGhvZCI6InRlcm1pbmF0aW9uLW1lc3NhZ2UiLCJNYXhSZXN1bHRTaXplIjo0MDk2LCJTZXRTZWN1cml0eUNvbnRleHQiOmZhbHNlLCJDb3NjaGVkdWxlIjoid29ya3NwYWNlcyJ9fX19",
+          "__decodedContent": {
+            "metadata": {
+              "name": "simple-build-run-e09d60fe56-build",
+              "namespace": "default",
+              "uid": "1e67b9f8-b86a-48ee-8945-6ebac1a6c9bb",
+              "resourceVersion": "2131",
+              "generation": 1,
+              "creationTimestamp": "2023-10-17T16:10:53Z",
+              "labels": {
+                "app.kubernetes.io/managed-by": "tekton-pipelines",
+                "tekton.dev/memberOf": "tasks",
+                "tekton.dev/pipeline": "simple-build",
+                "tekton.dev/pipelineRun": "simple-build-run-e09d60fe56",
+                "tekton.dev/pipelineTask": "build",
+                "tekton.dev/task": "mock-build"
+              },
+              "annotations": {
+                "chains.tekton.dev/signed": "true",
+                "pipeline.tekton.dev/release": "e7b5e58"
+              },
+              "ownerReferences": [
+                {
+                  "apiVersion": "tekton.dev/v1",
+                  "kind": "PipelineRun",
+                  "name": "simple-build-run-e09d60fe56",
+                  "uid": "61302bbc-e8c6-4059-9692-92036c9c0691",
+                  "controller": true,
+                  "blockOwnerDeletion": true
+                }
+              ],
+              "finalizers": [
+                "chains.tekton.dev"
+              ],
+              "managedFields": [
+                {
+                  "manager": "controller",
+                  "operation": "Update",
+                  "apiVersion": "tekton.dev/v1",
+                  "time": "2023-10-17T16:10:53Z",
+                  "fieldsType": "FieldsV1",
+                  "fieldsV1": {
+                    "f:metadata": {
+                      "f:annotations": {
+                        ".": {},
+                        "f:pipeline.tekton.dev/release": {}
+                      },
+                      "f:labels": {
+                        ".": {},
+                        "f:tekton.dev/memberOf": {},
+                        "f:tekton.dev/pipeline": {},
+                        "f:tekton.dev/pipelineRun": {},
+                        "f:tekton.dev/pipelineTask": {},
+                        "f:tekton.dev/task": {}
+                      },
+                      "f:ownerReferences": {
+                        ".": {},
+                        "k:{\"uid\":\"61302bbc-e8c6-4059-9692-92036c9c0691\"}": {}
+                      }
+                    },
+                    "f:spec": {
+                      ".": {},
+                      "f:params": {},
+                      "f:serviceAccountName": {},
+                      "f:taskRef": {
+                        ".": {},
+                        "f:kind": {},
+                        "f:params": {},
+                        "f:resolver": {}
+                      }
+                    }
+                  }
+                },
+                {
+                  "manager": "controller",
+                  "operation": "Update",
+                  "apiVersion": "tekton.dev/v1",
+                  "time": "2023-10-17T16:10:57Z",
+                  "fieldsType": "FieldsV1",
+                  "fieldsV1": {
+                    "f:status": {
+                      "f:completionTime": {},
+                      "f:conditions": {},
+                      "f:podName": {},
+                      "f:provenance": {
+                        ".": {},
+                        "f:featureFlags": {
+                          ".": {},
+                          "f:AwaitSidecarReadiness": {},
+                          "f:Coschedule": {},
+                          "f:DisableAffinityAssistant": {},
+                          "f:DisableCredsInit": {},
+                          "f:EnableAPIFields": {},
+                          "f:EnableProvenanceInStatus": {},
+                          "f:EnableTektonOCIBundles": {},
+                          "f:EnforceNonfalsifiability": {},
+                          "f:MaxResultSize": {},
+                          "f:RequireGitSSHSecretKnownHosts": {},
+                          "f:ResultExtractionMethod": {},
+                          "f:RunningInEnvWithInjectedSidecars": {},
+                          "f:ScopeWhenExpressionsToTask": {},
+                          "f:SendCloudEventsForRuns": {},
+                          "f:SetSecurityContext": {},
+                          "f:VerificationNoMatchPolicy": {}
+                        },
+                        "f:refSource": {
+                          ".": {},
+                          "f:digest": {
+                            ".": {},
+                            "f:sha256": {}
+                          },
+                          "f:entryPoint": {},
+                          "f:uri": {}
+                        }
+                      },
+                      "f:results": {},
+                      "f:startTime": {},
+                      "f:steps": {},
+                      "f:taskSpec": {
+                        ".": {},
+                        "f:description": {},
+                        "f:params": {},
+                        "f:results": {},
+                        "f:steps": {}
+                      }
+                    }
+                  },
+                  "subresource": "status"
+                },
+                {
+                  "manager": "controller",
+                  "operation": "Update",
+                  "apiVersion": "tekton.dev/v1beta1",
+                  "time": "2023-10-17T16:11:00Z",
+                  "fieldsType": "FieldsV1",
+                  "fieldsV1": {
+                    "f:metadata": {
+                      "f:annotations": {
+                        "f:chains.tekton.dev/signed": {}
+                      },
+                      "f:finalizers": {
+                        ".": {},
+                        "v:\"chains.tekton.dev\"": {}
+                      }
+                    }
+                  }
+                }
+              ]
+            },
+            "spec": {
+              "params": [
+                {
+                  "name": "IMAGE_URL",
+                  "value": "quay.io/lucarval/test-policies-chains"
+                },
+                {
+                  "name": "IMAGE_DIGEST",
+                  "value": "sha256:f6135ba64031dff85c0a9771776ad03135fecad75f572cb13917bd139f8c377c"
+                }
+              ],
+              "serviceAccountName": "default",
+              "taskRef": {
+                "kind": "Task",
+                "resolver": "bundles",
+                "params": [
+                  {
+                    "name": "bundle",
+                    "value": "quay.io/lucarval/test-policies-chains@sha256:c6ea74a4f8003179532dc2d74a51ef170be078acd4821fba15856d83eaa2d67a"
+                  },
+                  {
+                    "name": "name",
+                    "value": "mock-build"
+                  },
+                  {
+                    "name": "kind",
+                    "value": "task"
+                  }
+                ]
+              },
+              "timeout": "1h0m0s"
+            },
+            "status": {
+              "conditions": [
+                {
+                  "type": "Succeeded",
+                  "status": "True",
+                  "lastTransitionTime": "2023-10-17T16:10:57Z",
+                  "reason": "Succeeded",
+                  "message": "All Steps have completed executing"
+                }
+              ],
+              "podName": "simple-build-run-e09d60fe56-build-pod",
+              "startTime": "2023-10-17T16:10:53Z",
+              "completionTime": "2023-10-17T16:10:57Z",
+              "steps": [
+                {
+                  "terminated": {
+                    "exitCode": 0,
+                    "reason": "Completed",
+                    "message": "[{\"key\":\"IMAGE_DIGEST\",\"value\":\"sha256:f6135ba64031dff85c0a9771776ad03135fecad75f572cb13917bd139f8c377c\",\"type\":1},{\"key\":\"IMAGE_URL\",\"value\":\"quay.io/lucarval/test-policies-chains\",\"type\":1}]",
+                    "startedAt": "2023-10-17T16:10:57Z",
+                    "finishedAt": "2023-10-17T16:10:57Z",
+                    "containerID": "containerd://f31ebe16aa0714b473d95c8d7314c58d1c3f8353f37428a5c7cfcf931dfc6259"
+                  },
+                  "name": "build-and-push",
+                  "container": "step-build-and-push",
+                  "imageID": "registry.access.redhat.com/ubi9@sha256:20f695d2a91352d4eaa25107535126727b5945bff38ed36a3e59590f495046f0"
+                }
+              ],
+              "taskResults": [
+                {
+                  "name": "IMAGE_DIGEST",
+                  "type": "string",
+                  "value": "sha256:f6135ba64031dff85c0a9771776ad03135fecad75f572cb13917bd139f8c377c"
+                },
+                {
+                  "name": "IMAGE_URL",
+                  "type": "string",
+                  "value": "quay.io/lucarval/test-policies-chains"
+                }
+              ],
+              "taskSpec": {
+                "params": [
+                  {
+                    "name": "IMAGE_URL",
+                    "type": "string",
+                    "description": "The value to of the IMAGE_URL commit result."
+                  },
+                  {
+                    "name": "IMAGE_DIGEST",
+                    "type": "string",
+                    "description": "The value of the IMAGE_DIGEST result."
+                  }
+                ],
+                "description": "This is a dummy task that emulates a task that performs container build and push. Its sole purpose is to facilitate testing.",
+                "steps": [
+                  {
+                    "name": "build-and-push",
+                    "image": "registry.access.redhat.com/ubi9:latest",
+                    "env": [
+                      {
+                        "name": "IMAGE_URL",
+                        "value": "quay.io/lucarval/test-policies-chains"
+                      },
+                      {
+                        "name": "IMAGE_DIGEST",
+                        "value": "sha256:f6135ba64031dff85c0a9771776ad03135fecad75f572cb13917bd139f8c377c"
+                      }
+                    ],
+                    "resources": {},
+                    "script": "#!/usr/bin/env sh\nset -euo pipefail\n\necho -n \"${IMAGE_URL}\" > \"/tekton/results/IMAGE_URL\"\necho -n \"${IMAGE_DIGEST}\" > \"/tekton/results/IMAGE_DIGEST\"\n"
+                  }
+                ],
+                "results": [
+                  {
+                    "name": "IMAGE_URL",
+                    "type": "string",
+                    "description": "Image repository where the built image would be pushed to."
+                  },
+                  {
+                    "name": "IMAGE_DIGEST",
+                    "type": "string",
+                    "description": "Digest of the image just built."
+                  }
+                ]
+              },
+              "provenance": {
+                "refSource": {
+                  "uri": "quay.io/lucarval/test-policies-chains",
+                  "digest": {
+                    "sha256": "c6ea74a4f8003179532dc2d74a51ef170be078acd4821fba15856d83eaa2d67a"
+                  },
+                  "entryPoint": "mock-build"
+                },
+                "featureFlags": {
+                  "DisableAffinityAssistant": false,
+                  "DisableCredsInit": false,
+                  "RunningInEnvWithInjectedSidecars": true,
+                  "RequireGitSSHSecretKnownHosts": false,
+                  "EnableTektonOCIBundles": false,
+                  "ScopeWhenExpressionsToTask": false,
+                  "EnableAPIFields": "beta",
+                  "SendCloudEventsForRuns": false,
+                  "AwaitSidecarReadiness": true,
+                  "EnforceNonfalsifiability": "none",
+                  "VerificationNoMatchPolicy": "ignore",
+                  "EnableProvenanceInStatus": true,
+                  "ResultExtractionMethod": "termination-message",
+                  "MaxResultSize": 4096,
+                  "SetSecurityContext": false,
+                  "Coschedule": "workspaces"
+                }
+              }
+            }
+          }
+        },
+        {
+          "uri": "git+gitspam.spam/spam/spam.git",
+          "digest": {
+            "sha1": "f6aec6868913800133e2c61fb3183286ffd1551a"
+          },
+          "name": "inputs/result"
+        }
+      ]
+    },
+    "runDetails": {
+      "builder": {
+        "id": "https://tekton.dev/chains/v2"
+      },
+      "metadata": {
+        "invocationID": "61302bbc-e8c6-4059-9692-92036c9c0691",
+        "startedOn": "2023-10-17T16:10:44Z",
+        "finishedOn": "2023-10-17T16:10:57Z"
+      },
+      "byproducts": [
+        {
+          "name": "pipelineRunResults/IMAGE_URL",
+          "mediaType": "application/json",
+          "content": "InF1YXkuaW8vbHVjYXJ2YWwvdGVzdC1wb2xpY2llcy1jaGFpbnMi",
+          "__decodedContent": "quay.io/lucarval/test-policies-chains"
+        },
+        {
+          "name": "pipelineRunResults/IMAGE_DIGEST",
+          "mediaType": "application/json",
+          "content": "InNoYTI1NjpmNjEzNWJhNjQwMzFkZmY4NWMwYTk3NzE3NzZhZDAzMTM1ZmVjYWQ3NWY1NzJjYjEzOTE3YmQxMzlmOGMzNzdjIg==",
+          "__decodedContent": "sha256:f6135ba64031dff85c0a9771776ad03135fecad75f572cb13917bd139f8c377c"
+        },
+        {
+          "name": "pipelineRunResults/CHAINS-GIT_URL",
+          "mediaType": "application/json",
+          "content": "ImdpdHNwYW0uc3BhbS9zcGFtL3NwYW0i",
+          "__decodedContent": "gitspam.spam/spam/spam"
+        },
+        {
+          "name": "pipelineRunResults/CHAINS-GIT_COMMIT",
+          "mediaType": "application/json",
+          "content": "ImY2YWVjNjg2ODkxMzgwMDEzM2UyYzYxZmIzMTgzMjg2ZmZkMTU1MWEi",
+          "__decodedContent": "f6aec6868913800133e2c61fb3183286ffd1551a"
+        }
+      ]
+    }
+  }
+}

--- a/provenance/recordings/06-SLSA-v1-0-tekton-build-type-Pipeline-inline/decoded-content-att.json
+++ b/provenance/recordings/06-SLSA-v1-0-tekton-build-type-Pipeline-inline/decoded-content-att.json
@@ -1,0 +1,1190 @@
+{
+  "_type": "https://in-toto.io/Statement/v0.1",
+  "predicateType": "https://slsa.dev/provenance/v1",
+  "subject": [
+    {
+      "name": "quay.io/lucarval/test-policies-chains",
+      "digest": {
+        "sha256": "e70eb2f41605ff8635e69511279c4c8b3edd9f5f01c45d04f369965dd79a7640"
+      }
+    }
+  ],
+  "predicate": {
+    "buildDefinition": {
+      "buildType": "https://tekton.dev/chains/v2/slsa-tekton",
+      "externalParameters": {
+        "runSpec": {
+          "pipelineSpec": {
+            "tasks": [
+              {
+                "name": "git-clone",
+                "taskRef": {
+                  "kind": "Task",
+                  "resolver": "git",
+                  "params": [
+                    {
+                      "name": "url",
+                      "value": "https://github.com/lcarva/ec-policies.git"
+                    },
+                    {
+                      "name": "revision",
+                      "value": "727f8cae69fdfbae7cf8a44fd5e2055ad9573fb9"
+                    },
+                    {
+                      "name": "pathInRepo",
+                      "value": "integration/task/mock-git-clone.yaml"
+                    }
+                  ]
+                },
+                "params": [
+                  {
+                    "name": "commit",
+                    "value": "$(params.commit)"
+                  },
+                  {
+                    "name": "url",
+                    "value": "$(params.url)"
+                  },
+                  {
+                    "name": "committer-date",
+                    "value": "$(params.committer-date)"
+                  }
+                ]
+              },
+              {
+                "name": "scan",
+                "taskSpec": {
+                  "spec": null,
+                  "metadata": {},
+                  "params": [
+                    {
+                      "name": "TEST_OUTPUT",
+                      "type": "string",
+                      "description": "The value to of the TEST_OUTPUT commit result."
+                    }
+                  ],
+                  "description": "This is a dummy task that emulates a task that scans source code. Its sole purpose is to facilitate testing.",
+                  "steps": [
+                    {
+                      "name": "scan",
+                      "image": "registry.access.redhat.com/ubi9:latest",
+                      "env": [
+                        {
+                          "name": "TEST_OUTPUT",
+                          "value": "$(params.TEST_OUTPUT)"
+                        }
+                      ],
+                      "resources": {},
+                      "script": "#!/usr/bin/env sh\nset -euo pipefail\n\necho -n \"${TEST_OUTPUT}\" > \"$(results.TEST_OUTPUT.path)\"\n"
+                    }
+                  ],
+                  "results": [
+                    {
+                      "name": "TEST_OUTPUT",
+                      "type": "string",
+                      "description": "The summary scanner output."
+                    }
+                  ]
+                },
+                "runAfter": [
+                  "git-clone"
+                ],
+                "params": [
+                  {
+                    "name": "TEST_OUTPUT",
+                    "value": "$(params.TEST_OUTPUT)"
+                  }
+                ]
+              },
+              {
+                "name": "build",
+                "taskRef": {
+                  "kind": "Task",
+                  "resolver": "bundles",
+                  "params": [
+                    {
+                      "name": "bundle",
+                      "value": "quay.io/lucarval/test-policies-chains@sha256:a703e08dace201688ef9e37c023fac7b18c11694b5d40221a7880f21312879cc"
+                    },
+                    {
+                      "name": "name",
+                      "value": "mock-build"
+                    },
+                    {
+                      "name": "kind",
+                      "value": "task"
+                    }
+                  ]
+                },
+                "runAfter": [
+                  "scan"
+                ],
+                "params": [
+                  {
+                    "name": "IMAGE_URL",
+                    "value": "$(params.IMAGE_URL)"
+                  },
+                  {
+                    "name": "IMAGE_DIGEST",
+                    "value": "$(params.IMAGE_DIGEST)"
+                  }
+                ]
+              }
+            ],
+            "params": [
+              {
+                "name": "commit",
+                "type": "string"
+              },
+              {
+                "name": "url",
+                "type": "string"
+              },
+              {
+                "name": "committer-date",
+                "type": "string"
+              },
+              {
+                "name": "IMAGE_URL",
+                "type": "string"
+              },
+              {
+                "name": "IMAGE_DIGEST",
+                "type": "string"
+              },
+              {
+                "name": "TEST_OUTPUT",
+                "type": "string"
+              }
+            ],
+            "results": [
+              {
+                "name": "IMAGE_URL",
+                "description": "",
+                "value": "$(tasks.build.results.IMAGE_URL)"
+              },
+              {
+                "name": "IMAGE_DIGEST",
+                "description": "",
+                "value": "$(tasks.build.results.IMAGE_DIGEST)"
+              },
+              {
+                "name": "CHAINS-GIT_URL",
+                "description": "",
+                "value": "$(tasks.git-clone.results.url)"
+              },
+              {
+                "name": "CHAINS-GIT_COMMIT",
+                "description": "",
+                "value": "$(tasks.git-clone.results.commit)"
+              }
+            ]
+          },
+          "params": [
+            {
+              "name": "IMAGE_DIGEST",
+              "value": "sha256:e70eb2f41605ff8635e69511279c4c8b3edd9f5f01c45d04f369965dd79a7640"
+            },
+            {
+              "name": "IMAGE_URL",
+              "value": "quay.io/lucarval/test-policies-chains"
+            },
+            {
+              "name": "TEST_OUTPUT",
+              "value": "missing"
+            },
+            {
+              "name": "commit",
+              "value": "de952de1e1afb39b7ffd05c03cb76617cd36fed0"
+            },
+            {
+              "name": "committer-date",
+              "value": "1697559072"
+            },
+            {
+              "name": "url",
+              "value": "gitspam.spam/spam/spam"
+            }
+          ],
+          "serviceAccountName": "default",
+          "timeouts": {
+            "pipeline": "1h0m0s"
+          }
+        }
+      },
+      "internalParameters": {
+        "annotations": null,
+        "labels": {
+          "tekton.dev/pipeline": "simple-build-run-c9835084ef"
+        },
+        "tekton-pipelines-feature-flags": {
+          "DisableAffinityAssistant": false,
+          "DisableCredsInit": false,
+          "RunningInEnvWithInjectedSidecars": true,
+          "RequireGitSSHSecretKnownHosts": false,
+          "EnableTektonOCIBundles": false,
+          "ScopeWhenExpressionsToTask": false,
+          "EnableAPIFields": "beta",
+          "SendCloudEventsForRuns": false,
+          "AwaitSidecarReadiness": true,
+          "EnforceNonfalsifiability": "none",
+          "VerificationNoMatchPolicy": "ignore",
+          "EnableProvenanceInStatus": true,
+          "ResultExtractionMethod": "termination-message",
+          "MaxResultSize": 4096,
+          "SetSecurityContext": false,
+          "Coschedule": "workspaces"
+        }
+      },
+      "resolvedDependencies": [
+        {
+          "uri": "git+https://github.com/lcarva/ec-policies.git",
+          "digest": {
+            "sha1": "727f8cae69fdfbae7cf8a44fd5e2055ad9573fb9"
+          },
+          "name": "pipelineTask",
+          "content": "eyJtZXRhZGF0YSI6eyJuYW1lIjoic2ltcGxlLWJ1aWxkLXJ1bi1jOTgzNTA4NGVmLWdpdC1jbG9uZSIsIm5hbWVzcGFjZSI6ImRlZmF1bHQiLCJ1aWQiOiI1YjNhMThlYy02YzNmLTQzYjQtYTMyNy1iMWMyMWVkNjRjMDMiLCJyZXNvdXJjZVZlcnNpb24iOiIyMjg2IiwiZ2VuZXJhdGlvbiI6MSwiY3JlYXRpb25UaW1lc3RhbXAiOiIyMDIzLTEwLTE3VDE2OjExOjE0WiIsImxhYmVscyI6eyJhcHAua3ViZXJuZXRlcy5pby9tYW5hZ2VkLWJ5IjoidGVrdG9uLXBpcGVsaW5lcyIsInRla3Rvbi5kZXYvbWVtYmVyT2YiOiJ0YXNrcyIsInRla3Rvbi5kZXYvcGlwZWxpbmUiOiJzaW1wbGUtYnVpbGQtcnVuLWM5ODM1MDg0ZWYiLCJ0ZWt0b24uZGV2L3BpcGVsaW5lUnVuIjoic2ltcGxlLWJ1aWxkLXJ1bi1jOTgzNTA4NGVmIiwidGVrdG9uLmRldi9waXBlbGluZVRhc2siOiJnaXQtY2xvbmUiLCJ0ZWt0b24uZGV2L3Rhc2siOiJtb2NrLWdpdC1jbG9uZSJ9LCJhbm5vdGF0aW9ucyI6eyJjaGFpbnMudGVrdG9uLmRldi9zaWduZWQiOiJ0cnVlIiwicGlwZWxpbmUudGVrdG9uLmRldi9yZWxlYXNlIjoiZTdiNWU1OCJ9LCJvd25lclJlZmVyZW5jZXMiOlt7ImFwaVZlcnNpb24iOiJ0ZWt0b24uZGV2L3YxIiwia2luZCI6IlBpcGVsaW5lUnVuIiwibmFtZSI6InNpbXBsZS1idWlsZC1ydW4tYzk4MzUwODRlZiIsInVpZCI6IjFjZTJlM2JhLTZkYTEtNDMzZC1iNTZiLWI4YzNmZmNmMzQ0MyIsImNvbnRyb2xsZXIiOnRydWUsImJsb2NrT3duZXJEZWxldGlvbiI6dHJ1ZX1dLCJmaW5hbGl6ZXJzIjpbImNoYWlucy50ZWt0b24uZGV2Il0sIm1hbmFnZWRGaWVsZHMiOlt7Im1hbmFnZXIiOiJjb250cm9sbGVyIiwib3BlcmF0aW9uIjoiVXBkYXRlIiwiYXBpVmVyc2lvbiI6InRla3Rvbi5kZXYvdjEiLCJ0aW1lIjoiMjAyMy0xMC0xN1QxNjoxMToxNFoiLCJmaWVsZHNUeXBlIjoiRmllbGRzVjEiLCJmaWVsZHNWMSI6eyJmOm1ldGFkYXRhIjp7ImY6YW5ub3RhdGlvbnMiOnsiLiI6e30sImY6cGlwZWxpbmUudGVrdG9uLmRldi9yZWxlYXNlIjp7fX0sImY6bGFiZWxzIjp7Ii4iOnt9LCJmOnRla3Rvbi5kZXYvbWVtYmVyT2YiOnt9LCJmOnRla3Rvbi5kZXYvcGlwZWxpbmUiOnt9LCJmOnRla3Rvbi5kZXYvcGlwZWxpbmVSdW4iOnt9LCJmOnRla3Rvbi5kZXYvcGlwZWxpbmVUYXNrIjp7fSwiZjp0ZWt0b24uZGV2L3Rhc2siOnt9fSwiZjpvd25lclJlZmVyZW5jZXMiOnsiLiI6e30sIms6e1widWlkXCI6XCIxY2UyZTNiYS02ZGExLTQzM2QtYjU2Yi1iOGMzZmZjZjM0NDNcIn0iOnt9fX0sImY6c3BlYyI6eyIuIjp7fSwiZjpwYXJhbXMiOnt9LCJmOnNlcnZpY2VBY2NvdW50TmFtZSI6e30sImY6dGFza1JlZiI6eyIuIjp7fSwiZjpraW5kIjp7fSwiZjpwYXJhbXMiOnt9LCJmOnJlc29sdmVyIjp7fX19fX0seyJtYW5hZ2VyIjoiY29udHJvbGxlciIsIm9wZXJhdGlvbiI6IlVwZGF0ZSIsImFwaVZlcnNpb24iOiJ0ZWt0b24uZGV2L3YxIiwidGltZSI6IjIwMjMtMTAtMTdUMTY6MTE6MThaIiwiZmllbGRzVHlwZSI6IkZpZWxkc1YxIiwiZmllbGRzVjEiOnsiZjpzdGF0dXMiOnsiZjpjb21wbGV0aW9uVGltZSI6e30sImY6Y29uZGl0aW9ucyI6e30sImY6cG9kTmFtZSI6e30sImY6cHJvdmVuYW5jZSI6eyIuIjp7fSwiZjpmZWF0dXJlRmxhZ3MiOnsiLiI6e30sImY6QXdhaXRTaWRlY2FyUmVhZGluZXNzIjp7fSwiZjpDb3NjaGVkdWxlIjp7fSwiZjpEaXNhYmxlQWZmaW5pdHlBc3Npc3RhbnQiOnt9LCJmOkRpc2FibGVDcmVkc0luaXQiOnt9LCJmOkVuYWJsZUFQSUZpZWxkcyI6e30sImY6RW5hYmxlUHJvdmVuYW5jZUluU3RhdHVzIjp7fSwiZjpFbmFibGVUZWt0b25PQ0lCdW5kbGVzIjp7fSwiZjpFbmZvcmNlTm9uZmFsc2lmaWFiaWxpdHkiOnt9LCJmOk1heFJlc3VsdFNpemUiOnt9LCJmOlJlcXVpcmVHaXRTU0hTZWNyZXRLbm93bkhvc3RzIjp7fSwiZjpSZXN1bHRFeHRyYWN0aW9uTWV0aG9kIjp7fSwiZjpSdW5uaW5nSW5FbnZXaXRoSW5qZWN0ZWRTaWRlY2FycyI6e30sImY6U2NvcGVXaGVuRXhwcmVzc2lvbnNUb1Rhc2siOnt9LCJmOlNlbmRDbG91ZEV2ZW50c0ZvclJ1bnMiOnt9LCJmOlNldFNlY3VyaXR5Q29udGV4dCI6e30sImY6VmVyaWZpY2F0aW9uTm9NYXRjaFBvbGljeSI6e319LCJmOnJlZlNvdXJjZSI6eyIuIjp7fSwiZjpkaWdlc3QiOnsiLiI6e30sImY6c2hhMSI6e319LCJmOmVudHJ5UG9pbnQiOnt9LCJmOnVyaSI6e319fSwiZjpyZXN1bHRzIjp7fSwiZjpzdGFydFRpbWUiOnt9LCJmOnN0ZXBzIjp7fSwiZjp0YXNrU3BlYyI6eyIuIjp7fSwiZjpkZXNjcmlwdGlvbiI6e30sImY6cGFyYW1zIjp7fSwiZjpyZXN1bHRzIjp7fSwiZjpzdGVwcyI6e319fX0sInN1YnJlc291cmNlIjoic3RhdHVzIn0seyJtYW5hZ2VyIjoiY29udHJvbGxlciIsIm9wZXJhdGlvbiI6IlVwZGF0ZSIsImFwaVZlcnNpb24iOiJ0ZWt0b24uZGV2L3YxYmV0YTEiLCJ0aW1lIjoiMjAyMy0xMC0xN1QxNjoxMToxOVoiLCJmaWVsZHNUeXBlIjoiRmllbGRzVjEiLCJmaWVsZHNWMSI6eyJmOm1ldGFkYXRhIjp7ImY6YW5ub3RhdGlvbnMiOnsiZjpjaGFpbnMudGVrdG9uLmRldi9zaWduZWQiOnt9fSwiZjpmaW5hbGl6ZXJzIjp7Ii4iOnt9LCJ2OlwiY2hhaW5zLnRla3Rvbi5kZXZcIiI6e319fX19XX0sInNwZWMiOnsicGFyYW1zIjpbeyJuYW1lIjoiY29tbWl0IiwidmFsdWUiOiJkZTk1MmRlMWUxYWZiMzliN2ZmZDA1YzAzY2I3NjYxN2NkMzZmZWQwIn0seyJuYW1lIjoidXJsIiwidmFsdWUiOiJnaXRzcGFtLnNwYW0vc3BhbS9zcGFtIn0seyJuYW1lIjoiY29tbWl0dGVyLWRhdGUiLCJ2YWx1ZSI6IjE2OTc1NTkwNzIifV0sInNlcnZpY2VBY2NvdW50TmFtZSI6ImRlZmF1bHQiLCJ0YXNrUmVmIjp7ImtpbmQiOiJUYXNrIiwicmVzb2x2ZXIiOiJnaXQiLCJwYXJhbXMiOlt7Im5hbWUiOiJ1cmwiLCJ2YWx1ZSI6Imh0dHBzOi8vZ2l0aHViLmNvbS9sY2FydmEvZWMtcG9saWNpZXMuZ2l0In0seyJuYW1lIjoicmV2aXNpb24iLCJ2YWx1ZSI6IjcyN2Y4Y2FlNjlmZGZiYWU3Y2Y4YTQ0ZmQ1ZTIwNTVhZDk1NzNmYjkifSx7Im5hbWUiOiJwYXRoSW5SZXBvIiwidmFsdWUiOiJpbnRlZ3JhdGlvbi90YXNrL21vY2stZ2l0LWNsb25lLnlhbWwifV19LCJ0aW1lb3V0IjoiMWgwbTBzIn0sInN0YXR1cyI6eyJjb25kaXRpb25zIjpbeyJ0eXBlIjoiU3VjY2VlZGVkIiwic3RhdHVzIjoiVHJ1ZSIsImxhc3RUcmFuc2l0aW9uVGltZSI6IjIwMjMtMTAtMTdUMTY6MTE6MThaIiwicmVhc29uIjoiU3VjY2VlZGVkIiwibWVzc2FnZSI6IkFsbCBTdGVwcyBoYXZlIGNvbXBsZXRlZCBleGVjdXRpbmcifV0sInBvZE5hbWUiOiJzaW1wbGUtYnVpbGQtcnVuLWM5ODM1MDg0ZWYtZ2l0LWNsb25lLXBvZCIsInN0YXJ0VGltZSI6IjIwMjMtMTAtMTdUMTY6MTE6MTRaIiwiY29tcGxldGlvblRpbWUiOiIyMDIzLTEwLTE3VDE2OjExOjE4WiIsInN0ZXBzIjpbeyJ0ZXJtaW5hdGVkIjp7ImV4aXRDb2RlIjowLCJyZWFzb24iOiJDb21wbGV0ZWQiLCJtZXNzYWdlIjoiW3tcImtleVwiOlwiY29tbWl0XCIsXCJ2YWx1ZVwiOlwiZGU5NTJkZTFlMWFmYjM5YjdmZmQwNWMwM2NiNzY2MTdjZDM2ZmVkMFwiLFwidHlwZVwiOjF9LHtcImtleVwiOlwiY29tbWl0dGVyLWRhdGVcIixcInZhbHVlXCI6XCIxNjk3NTU5MDcyXCIsXCJ0eXBlXCI6MX0se1wia2V5XCI6XCJ1cmxcIixcInZhbHVlXCI6XCJnaXRzcGFtLnNwYW0vc3BhbS9zcGFtXCIsXCJ0eXBlXCI6MX1dIiwic3RhcnRlZEF0IjoiMjAyMy0xMC0xN1QxNjoxMToxOFoiLCJmaW5pc2hlZEF0IjoiMjAyMy0xMC0xN1QxNjoxMToxOFoiLCJjb250YWluZXJJRCI6ImNvbnRhaW5lcmQ6Ly82MWFlYTQ4ZDEzN2FkZWIwYTEyZmYwNjk5MGI5YTM2NjU1MDJlODUyNGI0MGI1MDEyOGQ2N2RiNzhkNzQyZjk1In0sIm5hbWUiOiJjbG9uZSIsImNvbnRhaW5lciI6InN0ZXAtY2xvbmUiLCJpbWFnZUlEIjoicmVnaXN0cnkuYWNjZXNzLnJlZGhhdC5jb20vdWJpOUBzaGEyNTY6MjBmNjk1ZDJhOTEzNTJkNGVhYTI1MTA3NTM1MTI2NzI3YjU5NDViZmYzOGVkMzZhM2U1OTU5MGY0OTUwNDZmMCJ9XSwidGFza1Jlc3VsdHMiOlt7Im5hbWUiOiJjb21taXQiLCJ0eXBlIjoic3RyaW5nIiwidmFsdWUiOiJkZTk1MmRlMWUxYWZiMzliN2ZmZDA1YzAzY2I3NjYxN2NkMzZmZWQwIn0seyJuYW1lIjoiY29tbWl0dGVyLWRhdGUiLCJ0eXBlIjoic3RyaW5nIiwidmFsdWUiOiIxNjk3NTU5MDcyIn0seyJuYW1lIjoidXJsIiwidHlwZSI6InN0cmluZyIsInZhbHVlIjoiZ2l0c3BhbS5zcGFtL3NwYW0vc3BhbSJ9XSwidGFza1NwZWMiOnsicGFyYW1zIjpbeyJuYW1lIjoiY29tbWl0IiwidHlwZSI6InN0cmluZyIsImRlc2NyaXB0aW9uIjoiVGhlIHZhbHVlIHRvIG9mIHRoZSBjb21taXQgcmVzdWx0LiJ9LHsibmFtZSI6InVybCIsInR5cGUiOiJzdHJpbmciLCJkZXNjcmlwdGlvbiI6IlRoZSB2YWx1ZSBvZiB0aGUgdXJsIHJlc3VsdC4ifSx7Im5hbWUiOiJjb21taXR0ZXItZGF0ZSIsInR5cGUiOiJzdHJpbmciLCJkZXNjcmlwdGlvbiI6IlRoZSB2YWx1ZSBvZiB0aGUgY29tbWl0dGVyLWRhdGUgcmVzdWx0LiJ9XSwiZGVzY3JpcHRpb24iOiJUaGlzIGlzIGEgZHVtbXkgdGFzayB0aGF0IGVtdWxhdGVzIGEgdGFzayB0aGF0IHBlcmZvcm1zIGEgZ2l0IGNsb25lLiBJdHMgc29sZSBwdXJwb3NlIGlzIHRvIGZhY2lsaXRhdGUgdGVzdGluZy4iLCJzdGVwcyI6W3sibmFtZSI6ImNsb25lIiwiaW1hZ2UiOiJyZWdpc3RyeS5hY2Nlc3MucmVkaGF0LmNvbS91Ymk5OmxhdGVzdCIsImVudiI6W3sibmFtZSI6IkNPTU1JVCIsInZhbHVlIjoiZGU5NTJkZTFlMWFmYjM5YjdmZmQwNWMwM2NiNzY2MTdjZDM2ZmVkMCJ9LHsibmFtZSI6IlVSTCIsInZhbHVlIjoiZ2l0c3BhbS5zcGFtL3NwYW0vc3BhbSJ9LHsibmFtZSI6IkNPTU1JVFRFUl9EQVRFIiwidmFsdWUiOiIxNjk3NTU5MDcyIn1dLCJyZXNvdXJjZXMiOnt9LCJzY3JpcHQiOiIjIS91c3IvYmluL2VudiBzaFxuc2V0IC1ldW8gcGlwZWZhaWxcblxuZWNobyAtbiBcIiR7Q09NTUlUfVwiIFx1MDAzZSBcIi90ZWt0b24vcmVzdWx0cy9jb21taXRcIlxuZWNobyAtbiBcIiR7VVJMfVwiIFx1MDAzZSBcIi90ZWt0b24vcmVzdWx0cy91cmxcIlxuZWNobyAtbiBcIiR7Q09NTUlUVEVSX0RBVEV9XCIgXHUwMDNlIFwiL3Rla3Rvbi9yZXN1bHRzL2NvbW1pdHRlci1kYXRlXCJcbiJ9XSwicmVzdWx0cyI6W3sibmFtZSI6ImNvbW1pdCIsInR5cGUiOiJzdHJpbmciLCJkZXNjcmlwdGlvbiI6IlRoZSBwcmVjaXNlIGNvbW1pdCBTSEEgdGhhdCB3YXMgZmV0Y2hlZCBieSB0aGlzIFRhc2suIn0seyJuYW1lIjoidXJsIiwidHlwZSI6InN0cmluZyIsImRlc2NyaXB0aW9uIjoiVGhlIHByZWNpc2UgVVJMIHRoYXQgd2FzIGZldGNoZWQgYnkgdGhpcyBUYXNrLiJ9LHsibmFtZSI6ImNvbW1pdHRlci1kYXRlIiwidHlwZSI6InN0cmluZyIsImRlc2NyaXB0aW9uIjoiVGhlIGVwb2NoIHRpbWVzdGFtcCBvZiB0aGUgY29tbWl0IHRoYXQgd2FzIGZldGNoZWQgYnkgdGhpcyBUYXNrLiJ9XX0sInByb3ZlbmFuY2UiOnsicmVmU291cmNlIjp7InVyaSI6ImdpdCtodHRwczovL2dpdGh1Yi5jb20vbGNhcnZhL2VjLXBvbGljaWVzLmdpdCIsImRpZ2VzdCI6eyJzaGExIjoiNzI3ZjhjYWU2OWZkZmJhZTdjZjhhNDRmZDVlMjA1NWFkOTU3M2ZiOSJ9LCJlbnRyeVBvaW50IjoiaW50ZWdyYXRpb24vdGFzay9tb2NrLWdpdC1jbG9uZS55YW1sIn0sImZlYXR1cmVGbGFncyI6eyJEaXNhYmxlQWZmaW5pdHlBc3Npc3RhbnQiOmZhbHNlLCJEaXNhYmxlQ3JlZHNJbml0IjpmYWxzZSwiUnVubmluZ0luRW52V2l0aEluamVjdGVkU2lkZWNhcnMiOnRydWUsIlJlcXVpcmVHaXRTU0hTZWNyZXRLbm93bkhvc3RzIjpmYWxzZSwiRW5hYmxlVGVrdG9uT0NJQnVuZGxlcyI6ZmFsc2UsIlNjb3BlV2hlbkV4cHJlc3Npb25zVG9UYXNrIjpmYWxzZSwiRW5hYmxlQVBJRmllbGRzIjoiYmV0YSIsIlNlbmRDbG91ZEV2ZW50c0ZvclJ1bnMiOmZhbHNlLCJBd2FpdFNpZGVjYXJSZWFkaW5lc3MiOnRydWUsIkVuZm9yY2VOb25mYWxzaWZpYWJpbGl0eSI6Im5vbmUiLCJWZXJpZmljYXRpb25Ob01hdGNoUG9saWN5IjoiaWdub3JlIiwiRW5hYmxlUHJvdmVuYW5jZUluU3RhdHVzIjp0cnVlLCJSZXN1bHRFeHRyYWN0aW9uTWV0aG9kIjoidGVybWluYXRpb24tbWVzc2FnZSIsIk1heFJlc3VsdFNpemUiOjQwOTYsIlNldFNlY3VyaXR5Q29udGV4dCI6ZmFsc2UsIkNvc2NoZWR1bGUiOiJ3b3Jrc3BhY2VzIn19fX0=",
+          "__decodedContent": {
+            "metadata": {
+              "name": "simple-build-run-c9835084ef-git-clone",
+              "namespace": "default",
+              "uid": "5b3a18ec-6c3f-43b4-a327-b1c21ed64c03",
+              "resourceVersion": "2286",
+              "generation": 1,
+              "creationTimestamp": "2023-10-17T16:11:14Z",
+              "labels": {
+                "app.kubernetes.io/managed-by": "tekton-pipelines",
+                "tekton.dev/memberOf": "tasks",
+                "tekton.dev/pipeline": "simple-build-run-c9835084ef",
+                "tekton.dev/pipelineRun": "simple-build-run-c9835084ef",
+                "tekton.dev/pipelineTask": "git-clone",
+                "tekton.dev/task": "mock-git-clone"
+              },
+              "annotations": {
+                "chains.tekton.dev/signed": "true",
+                "pipeline.tekton.dev/release": "e7b5e58"
+              },
+              "ownerReferences": [
+                {
+                  "apiVersion": "tekton.dev/v1",
+                  "kind": "PipelineRun",
+                  "name": "simple-build-run-c9835084ef",
+                  "uid": "1ce2e3ba-6da1-433d-b56b-b8c3ffcf3443",
+                  "controller": true,
+                  "blockOwnerDeletion": true
+                }
+              ],
+              "finalizers": [
+                "chains.tekton.dev"
+              ],
+              "managedFields": [
+                {
+                  "manager": "controller",
+                  "operation": "Update",
+                  "apiVersion": "tekton.dev/v1",
+                  "time": "2023-10-17T16:11:14Z",
+                  "fieldsType": "FieldsV1",
+                  "fieldsV1": {
+                    "f:metadata": {
+                      "f:annotations": {
+                        ".": {},
+                        "f:pipeline.tekton.dev/release": {}
+                      },
+                      "f:labels": {
+                        ".": {},
+                        "f:tekton.dev/memberOf": {},
+                        "f:tekton.dev/pipeline": {},
+                        "f:tekton.dev/pipelineRun": {},
+                        "f:tekton.dev/pipelineTask": {},
+                        "f:tekton.dev/task": {}
+                      },
+                      "f:ownerReferences": {
+                        ".": {},
+                        "k:{\"uid\":\"1ce2e3ba-6da1-433d-b56b-b8c3ffcf3443\"}": {}
+                      }
+                    },
+                    "f:spec": {
+                      ".": {},
+                      "f:params": {},
+                      "f:serviceAccountName": {},
+                      "f:taskRef": {
+                        ".": {},
+                        "f:kind": {},
+                        "f:params": {},
+                        "f:resolver": {}
+                      }
+                    }
+                  }
+                },
+                {
+                  "manager": "controller",
+                  "operation": "Update",
+                  "apiVersion": "tekton.dev/v1",
+                  "time": "2023-10-17T16:11:18Z",
+                  "fieldsType": "FieldsV1",
+                  "fieldsV1": {
+                    "f:status": {
+                      "f:completionTime": {},
+                      "f:conditions": {},
+                      "f:podName": {},
+                      "f:provenance": {
+                        ".": {},
+                        "f:featureFlags": {
+                          ".": {},
+                          "f:AwaitSidecarReadiness": {},
+                          "f:Coschedule": {},
+                          "f:DisableAffinityAssistant": {},
+                          "f:DisableCredsInit": {},
+                          "f:EnableAPIFields": {},
+                          "f:EnableProvenanceInStatus": {},
+                          "f:EnableTektonOCIBundles": {},
+                          "f:EnforceNonfalsifiability": {},
+                          "f:MaxResultSize": {},
+                          "f:RequireGitSSHSecretKnownHosts": {},
+                          "f:ResultExtractionMethod": {},
+                          "f:RunningInEnvWithInjectedSidecars": {},
+                          "f:ScopeWhenExpressionsToTask": {},
+                          "f:SendCloudEventsForRuns": {},
+                          "f:SetSecurityContext": {},
+                          "f:VerificationNoMatchPolicy": {}
+                        },
+                        "f:refSource": {
+                          ".": {},
+                          "f:digest": {
+                            ".": {},
+                            "f:sha1": {}
+                          },
+                          "f:entryPoint": {},
+                          "f:uri": {}
+                        }
+                      },
+                      "f:results": {},
+                      "f:startTime": {},
+                      "f:steps": {},
+                      "f:taskSpec": {
+                        ".": {},
+                        "f:description": {},
+                        "f:params": {},
+                        "f:results": {},
+                        "f:steps": {}
+                      }
+                    }
+                  },
+                  "subresource": "status"
+                },
+                {
+                  "manager": "controller",
+                  "operation": "Update",
+                  "apiVersion": "tekton.dev/v1beta1",
+                  "time": "2023-10-17T16:11:19Z",
+                  "fieldsType": "FieldsV1",
+                  "fieldsV1": {
+                    "f:metadata": {
+                      "f:annotations": {
+                        "f:chains.tekton.dev/signed": {}
+                      },
+                      "f:finalizers": {
+                        ".": {},
+                        "v:\"chains.tekton.dev\"": {}
+                      }
+                    }
+                  }
+                }
+              ]
+            },
+            "spec": {
+              "params": [
+                {
+                  "name": "commit",
+                  "value": "de952de1e1afb39b7ffd05c03cb76617cd36fed0"
+                },
+                {
+                  "name": "url",
+                  "value": "gitspam.spam/spam/spam"
+                },
+                {
+                  "name": "committer-date",
+                  "value": "1697559072"
+                }
+              ],
+              "serviceAccountName": "default",
+              "taskRef": {
+                "kind": "Task",
+                "resolver": "git",
+                "params": [
+                  {
+                    "name": "url",
+                    "value": "https://github.com/lcarva/ec-policies.git"
+                  },
+                  {
+                    "name": "revision",
+                    "value": "727f8cae69fdfbae7cf8a44fd5e2055ad9573fb9"
+                  },
+                  {
+                    "name": "pathInRepo",
+                    "value": "integration/task/mock-git-clone.yaml"
+                  }
+                ]
+              },
+              "timeout": "1h0m0s"
+            },
+            "status": {
+              "conditions": [
+                {
+                  "type": "Succeeded",
+                  "status": "True",
+                  "lastTransitionTime": "2023-10-17T16:11:18Z",
+                  "reason": "Succeeded",
+                  "message": "All Steps have completed executing"
+                }
+              ],
+              "podName": "simple-build-run-c9835084ef-git-clone-pod",
+              "startTime": "2023-10-17T16:11:14Z",
+              "completionTime": "2023-10-17T16:11:18Z",
+              "steps": [
+                {
+                  "terminated": {
+                    "exitCode": 0,
+                    "reason": "Completed",
+                    "message": "[{\"key\":\"commit\",\"value\":\"de952de1e1afb39b7ffd05c03cb76617cd36fed0\",\"type\":1},{\"key\":\"committer-date\",\"value\":\"1697559072\",\"type\":1},{\"key\":\"url\",\"value\":\"gitspam.spam/spam/spam\",\"type\":1}]",
+                    "startedAt": "2023-10-17T16:11:18Z",
+                    "finishedAt": "2023-10-17T16:11:18Z",
+                    "containerID": "containerd://61aea48d137adeb0a12ff06990b9a3665502e8524b40b50128d67db78d742f95"
+                  },
+                  "name": "clone",
+                  "container": "step-clone",
+                  "imageID": "registry.access.redhat.com/ubi9@sha256:20f695d2a91352d4eaa25107535126727b5945bff38ed36a3e59590f495046f0"
+                }
+              ],
+              "taskResults": [
+                {
+                  "name": "commit",
+                  "type": "string",
+                  "value": "de952de1e1afb39b7ffd05c03cb76617cd36fed0"
+                },
+                {
+                  "name": "committer-date",
+                  "type": "string",
+                  "value": "1697559072"
+                },
+                {
+                  "name": "url",
+                  "type": "string",
+                  "value": "gitspam.spam/spam/spam"
+                }
+              ],
+              "taskSpec": {
+                "params": [
+                  {
+                    "name": "commit",
+                    "type": "string",
+                    "description": "The value to of the commit result."
+                  },
+                  {
+                    "name": "url",
+                    "type": "string",
+                    "description": "The value of the url result."
+                  },
+                  {
+                    "name": "committer-date",
+                    "type": "string",
+                    "description": "The value of the committer-date result."
+                  }
+                ],
+                "description": "This is a dummy task that emulates a task that performs a git clone. Its sole purpose is to facilitate testing.",
+                "steps": [
+                  {
+                    "name": "clone",
+                    "image": "registry.access.redhat.com/ubi9:latest",
+                    "env": [
+                      {
+                        "name": "COMMIT",
+                        "value": "de952de1e1afb39b7ffd05c03cb76617cd36fed0"
+                      },
+                      {
+                        "name": "URL",
+                        "value": "gitspam.spam/spam/spam"
+                      },
+                      {
+                        "name": "COMMITTER_DATE",
+                        "value": "1697559072"
+                      }
+                    ],
+                    "resources": {},
+                    "script": "#!/usr/bin/env sh\nset -euo pipefail\n\necho -n \"${COMMIT}\" > \"/tekton/results/commit\"\necho -n \"${URL}\" > \"/tekton/results/url\"\necho -n \"${COMMITTER_DATE}\" > \"/tekton/results/committer-date\"\n"
+                  }
+                ],
+                "results": [
+                  {
+                    "name": "commit",
+                    "type": "string",
+                    "description": "The precise commit SHA that was fetched by this Task."
+                  },
+                  {
+                    "name": "url",
+                    "type": "string",
+                    "description": "The precise URL that was fetched by this Task."
+                  },
+                  {
+                    "name": "committer-date",
+                    "type": "string",
+                    "description": "The epoch timestamp of the commit that was fetched by this Task."
+                  }
+                ]
+              },
+              "provenance": {
+                "refSource": {
+                  "uri": "git+https://github.com/lcarva/ec-policies.git",
+                  "digest": {
+                    "sha1": "727f8cae69fdfbae7cf8a44fd5e2055ad9573fb9"
+                  },
+                  "entryPoint": "integration/task/mock-git-clone.yaml"
+                },
+                "featureFlags": {
+                  "DisableAffinityAssistant": false,
+                  "DisableCredsInit": false,
+                  "RunningInEnvWithInjectedSidecars": true,
+                  "RequireGitSSHSecretKnownHosts": false,
+                  "EnableTektonOCIBundles": false,
+                  "ScopeWhenExpressionsToTask": false,
+                  "EnableAPIFields": "beta",
+                  "SendCloudEventsForRuns": false,
+                  "AwaitSidecarReadiness": true,
+                  "EnforceNonfalsifiability": "none",
+                  "VerificationNoMatchPolicy": "ignore",
+                  "EnableProvenanceInStatus": true,
+                  "ResultExtractionMethod": "termination-message",
+                  "MaxResultSize": 4096,
+                  "SetSecurityContext": false,
+                  "Coschedule": "workspaces"
+                }
+              }
+            }
+          }
+        },
+        {
+          "uri": "oci://registry.access.redhat.com/ubi9",
+          "digest": {
+            "sha256": "20f695d2a91352d4eaa25107535126727b5945bff38ed36a3e59590f495046f0"
+          }
+        },
+        {
+          "name": "pipelineTask",
+          "content": "eyJtZXRhZGF0YSI6eyJuYW1lIjoic2ltcGxlLWJ1aWxkLXJ1bi1jOTgzNTA4NGVmLXNjYW4iLCJuYW1lc3BhY2UiOiJkZWZhdWx0IiwidWlkIjoiY2U0YzU4NGItOTU2Yi00NjU4LTk0NTYtZDYwOTMxNTFjMDc0IiwicmVzb3VyY2VWZXJzaW9uIjoiMjM0MyIsImdlbmVyYXRpb24iOjEsImNyZWF0aW9uVGltZXN0YW1wIjoiMjAyMy0xMC0xN1QxNjoxMToxOFoiLCJsYWJlbHMiOnsiYXBwLmt1YmVybmV0ZXMuaW8vbWFuYWdlZC1ieSI6InRla3Rvbi1waXBlbGluZXMiLCJ0ZWt0b24uZGV2L21lbWJlck9mIjoidGFza3MiLCJ0ZWt0b24uZGV2L3BpcGVsaW5lIjoic2ltcGxlLWJ1aWxkLXJ1bi1jOTgzNTA4NGVmIiwidGVrdG9uLmRldi9waXBlbGluZVJ1biI6InNpbXBsZS1idWlsZC1ydW4tYzk4MzUwODRlZiIsInRla3Rvbi5kZXYvcGlwZWxpbmVUYXNrIjoic2NhbiJ9LCJhbm5vdGF0aW9ucyI6eyJjaGFpbnMudGVrdG9uLmRldi9zaWduZWQiOiJ0cnVlIiwicGlwZWxpbmUudGVrdG9uLmRldi9yZWxlYXNlIjoiZTdiNWU1OCJ9LCJvd25lclJlZmVyZW5jZXMiOlt7ImFwaVZlcnNpb24iOiJ0ZWt0b24uZGV2L3YxIiwia2luZCI6IlBpcGVsaW5lUnVuIiwibmFtZSI6InNpbXBsZS1idWlsZC1ydW4tYzk4MzUwODRlZiIsInVpZCI6IjFjZTJlM2JhLTZkYTEtNDMzZC1iNTZiLWI4YzNmZmNmMzQ0MyIsImNvbnRyb2xsZXIiOnRydWUsImJsb2NrT3duZXJEZWxldGlvbiI6dHJ1ZX1dLCJmaW5hbGl6ZXJzIjpbImNoYWlucy50ZWt0b24uZGV2Il0sIm1hbmFnZWRGaWVsZHMiOlt7Im1hbmFnZXIiOiJjb250cm9sbGVyIiwib3BlcmF0aW9uIjoiVXBkYXRlIiwiYXBpVmVyc2lvbiI6InRla3Rvbi5kZXYvdjEiLCJ0aW1lIjoiMjAyMy0xMC0xN1QxNjoxMToxOVoiLCJmaWVsZHNUeXBlIjoiRmllbGRzVjEiLCJmaWVsZHNWMSI6eyJmOm1ldGFkYXRhIjp7ImY6YW5ub3RhdGlvbnMiOnsiLiI6e30sImY6cGlwZWxpbmUudGVrdG9uLmRldi9yZWxlYXNlIjp7fX0sImY6bGFiZWxzIjp7Ii4iOnt9LCJmOnRla3Rvbi5kZXYvbWVtYmVyT2YiOnt9LCJmOnRla3Rvbi5kZXYvcGlwZWxpbmUiOnt9LCJmOnRla3Rvbi5kZXYvcGlwZWxpbmVSdW4iOnt9LCJmOnRla3Rvbi5kZXYvcGlwZWxpbmVUYXNrIjp7fX0sImY6b3duZXJSZWZlcmVuY2VzIjp7Ii4iOnt9LCJrOntcInVpZFwiOlwiMWNlMmUzYmEtNmRhMS00MzNkLWI1NmItYjhjM2ZmY2YzNDQzXCJ9Ijp7fX19LCJmOnNwZWMiOnsiLiI6e30sImY6cGFyYW1zIjp7fSwiZjpzZXJ2aWNlQWNjb3VudE5hbWUiOnt9LCJmOnRhc2tTcGVjIjp7Ii4iOnt9LCJmOmRlc2NyaXB0aW9uIjp7fSwiZjpwYXJhbXMiOnt9LCJmOnJlc3VsdHMiOnt9LCJmOnN0ZXBzIjp7fX19fX0seyJtYW5hZ2VyIjoiY29udHJvbGxlciIsIm9wZXJhdGlvbiI6IlVwZGF0ZSIsImFwaVZlcnNpb24iOiJ0ZWt0b24uZGV2L3YxIiwidGltZSI6IjIwMjMtMTAtMTdUMTY6MTE6MjJaIiwiZmllbGRzVHlwZSI6IkZpZWxkc1YxIiwiZmllbGRzVjEiOnsiZjpzdGF0dXMiOnsiZjpjb21wbGV0aW9uVGltZSI6e30sImY6Y29uZGl0aW9ucyI6e30sImY6cG9kTmFtZSI6e30sImY6cHJvdmVuYW5jZSI6eyIuIjp7fSwiZjpmZWF0dXJlRmxhZ3MiOnsiLiI6e30sImY6QXdhaXRTaWRlY2FyUmVhZGluZXNzIjp7fSwiZjpDb3NjaGVkdWxlIjp7fSwiZjpEaXNhYmxlQWZmaW5pdHlBc3Npc3RhbnQiOnt9LCJmOkRpc2FibGVDcmVkc0luaXQiOnt9LCJmOkVuYWJsZUFQSUZpZWxkcyI6e30sImY6RW5hYmxlUHJvdmVuYW5jZUluU3RhdHVzIjp7fSwiZjpFbmFibGVUZWt0b25PQ0lCdW5kbGVzIjp7fSwiZjpFbmZvcmNlTm9uZmFsc2lmaWFiaWxpdHkiOnt9LCJmOk1heFJlc3VsdFNpemUiOnt9LCJmOlJlcXVpcmVHaXRTU0hTZWNyZXRLbm93bkhvc3RzIjp7fSwiZjpSZXN1bHRFeHRyYWN0aW9uTWV0aG9kIjp7fSwiZjpSdW5uaW5nSW5FbnZXaXRoSW5qZWN0ZWRTaWRlY2FycyI6e30sImY6U2NvcGVXaGVuRXhwcmVzc2lvbnNUb1Rhc2siOnt9LCJmOlNlbmRDbG91ZEV2ZW50c0ZvclJ1bnMiOnt9LCJmOlNldFNlY3VyaXR5Q29udGV4dCI6e30sImY6VmVyaWZpY2F0aW9uTm9NYXRjaFBvbGljeSI6e319fSwiZjpyZXN1bHRzIjp7fSwiZjpzdGFydFRpbWUiOnt9LCJmOnN0ZXBzIjp7fSwiZjp0YXNrU3BlYyI6eyIuIjp7fSwiZjpkZXNjcmlwdGlvbiI6e30sImY6cGFyYW1zIjp7fSwiZjpyZXN1bHRzIjp7fSwiZjpzdGVwcyI6e319fX0sInN1YnJlc291cmNlIjoic3RhdHVzIn0seyJtYW5hZ2VyIjoiY29udHJvbGxlciIsIm9wZXJhdGlvbiI6IlVwZGF0ZSIsImFwaVZlcnNpb24iOiJ0ZWt0b24uZGV2L3YxYmV0YTEiLCJ0aW1lIjoiMjAyMy0xMC0xN1QxNjoxMToyM1oiLCJmaWVsZHNUeXBlIjoiRmllbGRzVjEiLCJmaWVsZHNWMSI6eyJmOm1ldGFkYXRhIjp7ImY6YW5ub3RhdGlvbnMiOnsiZjpjaGFpbnMudGVrdG9uLmRldi9zaWduZWQiOnt9fSwiZjpmaW5hbGl6ZXJzIjp7Ii4iOnt9LCJ2OlwiY2hhaW5zLnRla3Rvbi5kZXZcIiI6e319fX19XX0sInNwZWMiOnsicGFyYW1zIjpbeyJuYW1lIjoiVEVTVF9PVVRQVVQiLCJ2YWx1ZSI6Im1pc3NpbmcifV0sInNlcnZpY2VBY2NvdW50TmFtZSI6ImRlZmF1bHQiLCJ0YXNrU3BlYyI6eyJwYXJhbXMiOlt7Im5hbWUiOiJURVNUX09VVFBVVCIsInR5cGUiOiJzdHJpbmciLCJkZXNjcmlwdGlvbiI6IlRoZSB2YWx1ZSB0byBvZiB0aGUgVEVTVF9PVVRQVVQgY29tbWl0IHJlc3VsdC4ifV0sImRlc2NyaXB0aW9uIjoiVGhpcyBpcyBhIGR1bW15IHRhc2sgdGhhdCBlbXVsYXRlcyBhIHRhc2sgdGhhdCBzY2FucyBzb3VyY2UgY29kZS4gSXRzIHNvbGUgcHVycG9zZSBpcyB0byBmYWNpbGl0YXRlIHRlc3RpbmcuIiwic3RlcHMiOlt7Im5hbWUiOiJzY2FuIiwiaW1hZ2UiOiJyZWdpc3RyeS5hY2Nlc3MucmVkaGF0LmNvbS91Ymk5OmxhdGVzdCIsImVudiI6W3sibmFtZSI6IlRFU1RfT1VUUFVUIiwidmFsdWUiOiJtaXNzaW5nIn1dLCJyZXNvdXJjZXMiOnt9LCJzY3JpcHQiOiIjIS91c3IvYmluL2VudiBzaFxuc2V0IC1ldW8gcGlwZWZhaWxcblxuZWNobyAtbiBcIiR7VEVTVF9PVVRQVVR9XCIgXHUwMDNlIFwiJChyZXN1bHRzLlRFU1RfT1VUUFVULnBhdGgpXCJcbiJ9XSwicmVzdWx0cyI6W3sibmFtZSI6IlRFU1RfT1VUUFVUIiwidHlwZSI6InN0cmluZyIsImRlc2NyaXB0aW9uIjoiVGhlIHN1bW1hcnkgc2Nhbm5lciBvdXRwdXQuIn1dfSwidGltZW91dCI6IjFoMG0wcyJ9LCJzdGF0dXMiOnsiY29uZGl0aW9ucyI6W3sidHlwZSI6IlN1Y2NlZWRlZCIsInN0YXR1cyI6IlRydWUiLCJsYXN0VHJhbnNpdGlvblRpbWUiOiIyMDIzLTEwLTE3VDE2OjExOjIyWiIsInJlYXNvbiI6IlN1Y2NlZWRlZCIsIm1lc3NhZ2UiOiJBbGwgU3RlcHMgaGF2ZSBjb21wbGV0ZWQgZXhlY3V0aW5nIn1dLCJwb2ROYW1lIjoic2ltcGxlLWJ1aWxkLXJ1bi1jOTgzNTA4NGVmLXNjYW4tcG9kIiwic3RhcnRUaW1lIjoiMjAyMy0xMC0xN1QxNjoxMToxOVoiLCJjb21wbGV0aW9uVGltZSI6IjIwMjMtMTAtMTdUMTY6MTE6MjJaIiwic3RlcHMiOlt7InRlcm1pbmF0ZWQiOnsiZXhpdENvZGUiOjAsInJlYXNvbiI6IkNvbXBsZXRlZCIsIm1lc3NhZ2UiOiJbe1wia2V5XCI6XCJURVNUX09VVFBVVFwiLFwidmFsdWVcIjpcIm1pc3NpbmdcIixcInR5cGVcIjoxfV0iLCJzdGFydGVkQXQiOiIyMDIzLTEwLTE3VDE2OjExOjIyWiIsImZpbmlzaGVkQXQiOiIyMDIzLTEwLTE3VDE2OjExOjIyWiIsImNvbnRhaW5lcklEIjoiY29udGFpbmVyZDovL2MwNjlkMjMzZWFkODBiODJlMjFiYThiOWFlNTNmOWM0MTRiNjJhMTU0M2I4ZmU3ZmE0ZDIzZWJlOGEzNTZiMjcifSwibmFtZSI6InNjYW4iLCJjb250YWluZXIiOiJzdGVwLXNjYW4iLCJpbWFnZUlEIjoicmVnaXN0cnkuYWNjZXNzLnJlZGhhdC5jb20vdWJpOUBzaGEyNTY6MjBmNjk1ZDJhOTEzNTJkNGVhYTI1MTA3NTM1MTI2NzI3YjU5NDViZmYzOGVkMzZhM2U1OTU5MGY0OTUwNDZmMCJ9XSwidGFza1Jlc3VsdHMiOlt7Im5hbWUiOiJURVNUX09VVFBVVCIsInR5cGUiOiJzdHJpbmciLCJ2YWx1ZSI6Im1pc3NpbmcifV0sInRhc2tTcGVjIjp7InBhcmFtcyI6W3sibmFtZSI6IlRFU1RfT1VUUFVUIiwidHlwZSI6InN0cmluZyIsImRlc2NyaXB0aW9uIjoiVGhlIHZhbHVlIHRvIG9mIHRoZSBURVNUX09VVFBVVCBjb21taXQgcmVzdWx0LiJ9XSwiZGVzY3JpcHRpb24iOiJUaGlzIGlzIGEgZHVtbXkgdGFzayB0aGF0IGVtdWxhdGVzIGEgdGFzayB0aGF0IHNjYW5zIHNvdXJjZSBjb2RlLiBJdHMgc29sZSBwdXJwb3NlIGlzIHRvIGZhY2lsaXRhdGUgdGVzdGluZy4iLCJzdGVwcyI6W3sibmFtZSI6InNjYW4iLCJpbWFnZSI6InJlZ2lzdHJ5LmFjY2Vzcy5yZWRoYXQuY29tL3ViaTk6bGF0ZXN0IiwiZW52IjpbeyJuYW1lIjoiVEVTVF9PVVRQVVQiLCJ2YWx1ZSI6Im1pc3NpbmcifV0sInJlc291cmNlcyI6e30sInNjcmlwdCI6IiMhL3Vzci9iaW4vZW52IHNoXG5zZXQgLWV1byBwaXBlZmFpbFxuXG5lY2hvIC1uIFwiJHtURVNUX09VVFBVVH1cIiBcdTAwM2UgXCIvdGVrdG9uL3Jlc3VsdHMvVEVTVF9PVVRQVVRcIlxuIn1dLCJyZXN1bHRzIjpbeyJuYW1lIjoiVEVTVF9PVVRQVVQiLCJ0eXBlIjoic3RyaW5nIiwiZGVzY3JpcHRpb24iOiJUaGUgc3VtbWFyeSBzY2FubmVyIG91dHB1dC4ifV19LCJwcm92ZW5hbmNlIjp7ImZlYXR1cmVGbGFncyI6eyJEaXNhYmxlQWZmaW5pdHlBc3Npc3RhbnQiOmZhbHNlLCJEaXNhYmxlQ3JlZHNJbml0IjpmYWxzZSwiUnVubmluZ0luRW52V2l0aEluamVjdGVkU2lkZWNhcnMiOnRydWUsIlJlcXVpcmVHaXRTU0hTZWNyZXRLbm93bkhvc3RzIjpmYWxzZSwiRW5hYmxlVGVrdG9uT0NJQnVuZGxlcyI6ZmFsc2UsIlNjb3BlV2hlbkV4cHJlc3Npb25zVG9UYXNrIjpmYWxzZSwiRW5hYmxlQVBJRmllbGRzIjoiYmV0YSIsIlNlbmRDbG91ZEV2ZW50c0ZvclJ1bnMiOmZhbHNlLCJBd2FpdFNpZGVjYXJSZWFkaW5lc3MiOnRydWUsIkVuZm9yY2VOb25mYWxzaWZpYWJpbGl0eSI6Im5vbmUiLCJWZXJpZmljYXRpb25Ob01hdGNoUG9saWN5IjoiaWdub3JlIiwiRW5hYmxlUHJvdmVuYW5jZUluU3RhdHVzIjp0cnVlLCJSZXN1bHRFeHRyYWN0aW9uTWV0aG9kIjoidGVybWluYXRpb24tbWVzc2FnZSIsIk1heFJlc3VsdFNpemUiOjQwOTYsIlNldFNlY3VyaXR5Q29udGV4dCI6ZmFsc2UsIkNvc2NoZWR1bGUiOiJ3b3Jrc3BhY2VzIn19fX0=",
+          "__decodedContent": {
+            "metadata": {
+              "name": "simple-build-run-c9835084ef-scan",
+              "namespace": "default",
+              "uid": "ce4c584b-956b-4658-9456-d6093151c074",
+              "resourceVersion": "2343",
+              "generation": 1,
+              "creationTimestamp": "2023-10-17T16:11:18Z",
+              "labels": {
+                "app.kubernetes.io/managed-by": "tekton-pipelines",
+                "tekton.dev/memberOf": "tasks",
+                "tekton.dev/pipeline": "simple-build-run-c9835084ef",
+                "tekton.dev/pipelineRun": "simple-build-run-c9835084ef",
+                "tekton.dev/pipelineTask": "scan"
+              },
+              "annotations": {
+                "chains.tekton.dev/signed": "true",
+                "pipeline.tekton.dev/release": "e7b5e58"
+              },
+              "ownerReferences": [
+                {
+                  "apiVersion": "tekton.dev/v1",
+                  "kind": "PipelineRun",
+                  "name": "simple-build-run-c9835084ef",
+                  "uid": "1ce2e3ba-6da1-433d-b56b-b8c3ffcf3443",
+                  "controller": true,
+                  "blockOwnerDeletion": true
+                }
+              ],
+              "finalizers": [
+                "chains.tekton.dev"
+              ],
+              "managedFields": [
+                {
+                  "manager": "controller",
+                  "operation": "Update",
+                  "apiVersion": "tekton.dev/v1",
+                  "time": "2023-10-17T16:11:19Z",
+                  "fieldsType": "FieldsV1",
+                  "fieldsV1": {
+                    "f:metadata": {
+                      "f:annotations": {
+                        ".": {},
+                        "f:pipeline.tekton.dev/release": {}
+                      },
+                      "f:labels": {
+                        ".": {},
+                        "f:tekton.dev/memberOf": {},
+                        "f:tekton.dev/pipeline": {},
+                        "f:tekton.dev/pipelineRun": {},
+                        "f:tekton.dev/pipelineTask": {}
+                      },
+                      "f:ownerReferences": {
+                        ".": {},
+                        "k:{\"uid\":\"1ce2e3ba-6da1-433d-b56b-b8c3ffcf3443\"}": {}
+                      }
+                    },
+                    "f:spec": {
+                      ".": {},
+                      "f:params": {},
+                      "f:serviceAccountName": {},
+                      "f:taskSpec": {
+                        ".": {},
+                        "f:description": {},
+                        "f:params": {},
+                        "f:results": {},
+                        "f:steps": {}
+                      }
+                    }
+                  }
+                },
+                {
+                  "manager": "controller",
+                  "operation": "Update",
+                  "apiVersion": "tekton.dev/v1",
+                  "time": "2023-10-17T16:11:22Z",
+                  "fieldsType": "FieldsV1",
+                  "fieldsV1": {
+                    "f:status": {
+                      "f:completionTime": {},
+                      "f:conditions": {},
+                      "f:podName": {},
+                      "f:provenance": {
+                        ".": {},
+                        "f:featureFlags": {
+                          ".": {},
+                          "f:AwaitSidecarReadiness": {},
+                          "f:Coschedule": {},
+                          "f:DisableAffinityAssistant": {},
+                          "f:DisableCredsInit": {},
+                          "f:EnableAPIFields": {},
+                          "f:EnableProvenanceInStatus": {},
+                          "f:EnableTektonOCIBundles": {},
+                          "f:EnforceNonfalsifiability": {},
+                          "f:MaxResultSize": {},
+                          "f:RequireGitSSHSecretKnownHosts": {},
+                          "f:ResultExtractionMethod": {},
+                          "f:RunningInEnvWithInjectedSidecars": {},
+                          "f:ScopeWhenExpressionsToTask": {},
+                          "f:SendCloudEventsForRuns": {},
+                          "f:SetSecurityContext": {},
+                          "f:VerificationNoMatchPolicy": {}
+                        }
+                      },
+                      "f:results": {},
+                      "f:startTime": {},
+                      "f:steps": {},
+                      "f:taskSpec": {
+                        ".": {},
+                        "f:description": {},
+                        "f:params": {},
+                        "f:results": {},
+                        "f:steps": {}
+                      }
+                    }
+                  },
+                  "subresource": "status"
+                },
+                {
+                  "manager": "controller",
+                  "operation": "Update",
+                  "apiVersion": "tekton.dev/v1beta1",
+                  "time": "2023-10-17T16:11:23Z",
+                  "fieldsType": "FieldsV1",
+                  "fieldsV1": {
+                    "f:metadata": {
+                      "f:annotations": {
+                        "f:chains.tekton.dev/signed": {}
+                      },
+                      "f:finalizers": {
+                        ".": {},
+                        "v:\"chains.tekton.dev\"": {}
+                      }
+                    }
+                  }
+                }
+              ]
+            },
+            "spec": {
+              "params": [
+                {
+                  "name": "TEST_OUTPUT",
+                  "value": "missing"
+                }
+              ],
+              "serviceAccountName": "default",
+              "taskSpec": {
+                "params": [
+                  {
+                    "name": "TEST_OUTPUT",
+                    "type": "string",
+                    "description": "The value to of the TEST_OUTPUT commit result."
+                  }
+                ],
+                "description": "This is a dummy task that emulates a task that scans source code. Its sole purpose is to facilitate testing.",
+                "steps": [
+                  {
+                    "name": "scan",
+                    "image": "registry.access.redhat.com/ubi9:latest",
+                    "env": [
+                      {
+                        "name": "TEST_OUTPUT",
+                        "value": "missing"
+                      }
+                    ],
+                    "resources": {},
+                    "script": "#!/usr/bin/env sh\nset -euo pipefail\n\necho -n \"${TEST_OUTPUT}\" > \"$(results.TEST_OUTPUT.path)\"\n"
+                  }
+                ],
+                "results": [
+                  {
+                    "name": "TEST_OUTPUT",
+                    "type": "string",
+                    "description": "The summary scanner output."
+                  }
+                ]
+              },
+              "timeout": "1h0m0s"
+            },
+            "status": {
+              "conditions": [
+                {
+                  "type": "Succeeded",
+                  "status": "True",
+                  "lastTransitionTime": "2023-10-17T16:11:22Z",
+                  "reason": "Succeeded",
+                  "message": "All Steps have completed executing"
+                }
+              ],
+              "podName": "simple-build-run-c9835084ef-scan-pod",
+              "startTime": "2023-10-17T16:11:19Z",
+              "completionTime": "2023-10-17T16:11:22Z",
+              "steps": [
+                {
+                  "terminated": {
+                    "exitCode": 0,
+                    "reason": "Completed",
+                    "message": "[{\"key\":\"TEST_OUTPUT\",\"value\":\"missing\",\"type\":1}]",
+                    "startedAt": "2023-10-17T16:11:22Z",
+                    "finishedAt": "2023-10-17T16:11:22Z",
+                    "containerID": "containerd://c069d233ead80b82e21ba8b9ae53f9c414b62a1543b8fe7fa4d23ebe8a356b27"
+                  },
+                  "name": "scan",
+                  "container": "step-scan",
+                  "imageID": "registry.access.redhat.com/ubi9@sha256:20f695d2a91352d4eaa25107535126727b5945bff38ed36a3e59590f495046f0"
+                }
+              ],
+              "taskResults": [
+                {
+                  "name": "TEST_OUTPUT",
+                  "type": "string",
+                  "value": "missing"
+                }
+              ],
+              "taskSpec": {
+                "params": [
+                  {
+                    "name": "TEST_OUTPUT",
+                    "type": "string",
+                    "description": "The value to of the TEST_OUTPUT commit result."
+                  }
+                ],
+                "description": "This is a dummy task that emulates a task that scans source code. Its sole purpose is to facilitate testing.",
+                "steps": [
+                  {
+                    "name": "scan",
+                    "image": "registry.access.redhat.com/ubi9:latest",
+                    "env": [
+                      {
+                        "name": "TEST_OUTPUT",
+                        "value": "missing"
+                      }
+                    ],
+                    "resources": {},
+                    "script": "#!/usr/bin/env sh\nset -euo pipefail\n\necho -n \"${TEST_OUTPUT}\" > \"/tekton/results/TEST_OUTPUT\"\n"
+                  }
+                ],
+                "results": [
+                  {
+                    "name": "TEST_OUTPUT",
+                    "type": "string",
+                    "description": "The summary scanner output."
+                  }
+                ]
+              },
+              "provenance": {
+                "featureFlags": {
+                  "DisableAffinityAssistant": false,
+                  "DisableCredsInit": false,
+                  "RunningInEnvWithInjectedSidecars": true,
+                  "RequireGitSSHSecretKnownHosts": false,
+                  "EnableTektonOCIBundles": false,
+                  "ScopeWhenExpressionsToTask": false,
+                  "EnableAPIFields": "beta",
+                  "SendCloudEventsForRuns": false,
+                  "AwaitSidecarReadiness": true,
+                  "EnforceNonfalsifiability": "none",
+                  "VerificationNoMatchPolicy": "ignore",
+                  "EnableProvenanceInStatus": true,
+                  "ResultExtractionMethod": "termination-message",
+                  "MaxResultSize": 4096,
+                  "SetSecurityContext": false,
+                  "Coschedule": "workspaces"
+                }
+              }
+            }
+          }
+        },
+        {
+          "uri": "quay.io/lucarval/test-policies-chains",
+          "digest": {
+            "sha256": "a703e08dace201688ef9e37c023fac7b18c11694b5d40221a7880f21312879cc"
+          },
+          "name": "pipelineTask",
+          "content": "eyJtZXRhZGF0YSI6eyJuYW1lIjoic2ltcGxlLWJ1aWxkLXJ1bi1jOTgzNTA4NGVmLWJ1aWxkIiwibmFtZXNwYWNlIjoiZGVmYXVsdCIsInVpZCI6IjVkZTgwNjExLTAzOWQtNDJmYi04NjQzLWE3Y2M2ZTY5MjhiYiIsInJlc291cmNlVmVyc2lvbiI6IjIzODkiLCJnZW5lcmF0aW9uIjoxLCJjcmVhdGlvblRpbWVzdGFtcCI6IjIwMjMtMTAtMTdUMTY6MTE6MjNaIiwibGFiZWxzIjp7ImFwcC5rdWJlcm5ldGVzLmlvL21hbmFnZWQtYnkiOiJ0ZWt0b24tcGlwZWxpbmVzIiwidGVrdG9uLmRldi9tZW1iZXJPZiI6InRhc2tzIiwidGVrdG9uLmRldi9waXBlbGluZSI6InNpbXBsZS1idWlsZC1ydW4tYzk4MzUwODRlZiIsInRla3Rvbi5kZXYvcGlwZWxpbmVSdW4iOiJzaW1wbGUtYnVpbGQtcnVuLWM5ODM1MDg0ZWYiLCJ0ZWt0b24uZGV2L3BpcGVsaW5lVGFzayI6ImJ1aWxkIiwidGVrdG9uLmRldi90YXNrIjoibW9jay1idWlsZCJ9LCJhbm5vdGF0aW9ucyI6eyJjaGFpbnMudGVrdG9uLmRldi9zaWduZWQiOiJ0cnVlIiwicGlwZWxpbmUudGVrdG9uLmRldi9yZWxlYXNlIjoiZTdiNWU1OCJ9LCJvd25lclJlZmVyZW5jZXMiOlt7ImFwaVZlcnNpb24iOiJ0ZWt0b24uZGV2L3YxIiwia2luZCI6IlBpcGVsaW5lUnVuIiwibmFtZSI6InNpbXBsZS1idWlsZC1ydW4tYzk4MzUwODRlZiIsInVpZCI6IjFjZTJlM2JhLTZkYTEtNDMzZC1iNTZiLWI4YzNmZmNmMzQ0MyIsImNvbnRyb2xsZXIiOnRydWUsImJsb2NrT3duZXJEZWxldGlvbiI6dHJ1ZX1dLCJmaW5hbGl6ZXJzIjpbImNoYWlucy50ZWt0b24uZGV2Il0sIm1hbmFnZWRGaWVsZHMiOlt7Im1hbmFnZXIiOiJjb250cm9sbGVyIiwib3BlcmF0aW9uIjoiVXBkYXRlIiwiYXBpVmVyc2lvbiI6InRla3Rvbi5kZXYvdjEiLCJ0aW1lIjoiMjAyMy0xMC0xN1QxNjoxMToyM1oiLCJmaWVsZHNUeXBlIjoiRmllbGRzVjEiLCJmaWVsZHNWMSI6eyJmOm1ldGFkYXRhIjp7ImY6YW5ub3RhdGlvbnMiOnsiLiI6e30sImY6cGlwZWxpbmUudGVrdG9uLmRldi9yZWxlYXNlIjp7fX0sImY6bGFiZWxzIjp7Ii4iOnt9LCJmOnRla3Rvbi5kZXYvbWVtYmVyT2YiOnt9LCJmOnRla3Rvbi5kZXYvcGlwZWxpbmUiOnt9LCJmOnRla3Rvbi5kZXYvcGlwZWxpbmVSdW4iOnt9LCJmOnRla3Rvbi5kZXYvcGlwZWxpbmVUYXNrIjp7fSwiZjp0ZWt0b24uZGV2L3Rhc2siOnt9fSwiZjpvd25lclJlZmVyZW5jZXMiOnsiLiI6e30sIms6e1widWlkXCI6XCIxY2UyZTNiYS02ZGExLTQzM2QtYjU2Yi1iOGMzZmZjZjM0NDNcIn0iOnt9fX0sImY6c3BlYyI6eyIuIjp7fSwiZjpwYXJhbXMiOnt9LCJmOnNlcnZpY2VBY2NvdW50TmFtZSI6e30sImY6dGFza1JlZiI6eyIuIjp7fSwiZjpraW5kIjp7fSwiZjpwYXJhbXMiOnt9LCJmOnJlc29sdmVyIjp7fX19fX0seyJtYW5hZ2VyIjoiY29udHJvbGxlciIsIm9wZXJhdGlvbiI6IlVwZGF0ZSIsImFwaVZlcnNpb24iOiJ0ZWt0b24uZGV2L3YxIiwidGltZSI6IjIwMjMtMTAtMTdUMTY6MTE6MjZaIiwiZmllbGRzVHlwZSI6IkZpZWxkc1YxIiwiZmllbGRzVjEiOnsiZjpzdGF0dXMiOnsiZjpjb21wbGV0aW9uVGltZSI6e30sImY6Y29uZGl0aW9ucyI6e30sImY6cG9kTmFtZSI6e30sImY6cHJvdmVuYW5jZSI6eyIuIjp7fSwiZjpmZWF0dXJlRmxhZ3MiOnsiLiI6e30sImY6QXdhaXRTaWRlY2FyUmVhZGluZXNzIjp7fSwiZjpDb3NjaGVkdWxlIjp7fSwiZjpEaXNhYmxlQWZmaW5pdHlBc3Npc3RhbnQiOnt9LCJmOkRpc2FibGVDcmVkc0luaXQiOnt9LCJmOkVuYWJsZUFQSUZpZWxkcyI6e30sImY6RW5hYmxlUHJvdmVuYW5jZUluU3RhdHVzIjp7fSwiZjpFbmFibGVUZWt0b25PQ0lCdW5kbGVzIjp7fSwiZjpFbmZvcmNlTm9uZmFsc2lmaWFiaWxpdHkiOnt9LCJmOk1heFJlc3VsdFNpemUiOnt9LCJmOlJlcXVpcmVHaXRTU0hTZWNyZXRLbm93bkhvc3RzIjp7fSwiZjpSZXN1bHRFeHRyYWN0aW9uTWV0aG9kIjp7fSwiZjpSdW5uaW5nSW5FbnZXaXRoSW5qZWN0ZWRTaWRlY2FycyI6e30sImY6U2NvcGVXaGVuRXhwcmVzc2lvbnNUb1Rhc2siOnt9LCJmOlNlbmRDbG91ZEV2ZW50c0ZvclJ1bnMiOnt9LCJmOlNldFNlY3VyaXR5Q29udGV4dCI6e30sImY6VmVyaWZpY2F0aW9uTm9NYXRjaFBvbGljeSI6e319LCJmOnJlZlNvdXJjZSI6eyIuIjp7fSwiZjpkaWdlc3QiOnsiLiI6e30sImY6c2hhMjU2Ijp7fX0sImY6ZW50cnlQb2ludCI6e30sImY6dXJpIjp7fX19LCJmOnJlc3VsdHMiOnt9LCJmOnN0YXJ0VGltZSI6e30sImY6c3RlcHMiOnt9LCJmOnRhc2tTcGVjIjp7Ii4iOnt9LCJmOmRlc2NyaXB0aW9uIjp7fSwiZjpwYXJhbXMiOnt9LCJmOnJlc3VsdHMiOnt9LCJmOnN0ZXBzIjp7fX19fSwic3VicmVzb3VyY2UiOiJzdGF0dXMifSx7Im1hbmFnZXIiOiJjb250cm9sbGVyIiwib3BlcmF0aW9uIjoiVXBkYXRlIiwiYXBpVmVyc2lvbiI6InRla3Rvbi5kZXYvdjFiZXRhMSIsInRpbWUiOiIyMDIzLTEwLTE3VDE2OjExOjMwWiIsImZpZWxkc1R5cGUiOiJGaWVsZHNWMSIsImZpZWxkc1YxIjp7ImY6bWV0YWRhdGEiOnsiZjphbm5vdGF0aW9ucyI6eyJmOmNoYWlucy50ZWt0b24uZGV2L3NpZ25lZCI6e319LCJmOmZpbmFsaXplcnMiOnsiLiI6e30sInY6XCJjaGFpbnMudGVrdG9uLmRldlwiIjp7fX19fX1dfSwic3BlYyI6eyJwYXJhbXMiOlt7Im5hbWUiOiJJTUFHRV9VUkwiLCJ2YWx1ZSI6InF1YXkuaW8vbHVjYXJ2YWwvdGVzdC1wb2xpY2llcy1jaGFpbnMifSx7Im5hbWUiOiJJTUFHRV9ESUdFU1QiLCJ2YWx1ZSI6InNoYTI1NjplNzBlYjJmNDE2MDVmZjg2MzVlNjk1MTEyNzljNGM4YjNlZGQ5ZjVmMDFjNDVkMDRmMzY5OTY1ZGQ3OWE3NjQwIn1dLCJzZXJ2aWNlQWNjb3VudE5hbWUiOiJkZWZhdWx0IiwidGFza1JlZiI6eyJraW5kIjoiVGFzayIsInJlc29sdmVyIjoiYnVuZGxlcyIsInBhcmFtcyI6W3sibmFtZSI6ImJ1bmRsZSIsInZhbHVlIjoicXVheS5pby9sdWNhcnZhbC90ZXN0LXBvbGljaWVzLWNoYWluc0BzaGEyNTY6YTcwM2UwOGRhY2UyMDE2ODhlZjllMzdjMDIzZmFjN2IxOGMxMTY5NGI1ZDQwMjIxYTc4ODBmMjEzMTI4NzljYyJ9LHsibmFtZSI6Im5hbWUiLCJ2YWx1ZSI6Im1vY2stYnVpbGQifSx7Im5hbWUiOiJraW5kIiwidmFsdWUiOiJ0YXNrIn1dfSwidGltZW91dCI6IjFoMG0wcyJ9LCJzdGF0dXMiOnsiY29uZGl0aW9ucyI6W3sidHlwZSI6IlN1Y2NlZWRlZCIsInN0YXR1cyI6IlRydWUiLCJsYXN0VHJhbnNpdGlvblRpbWUiOiIyMDIzLTEwLTE3VDE2OjExOjI2WiIsInJlYXNvbiI6IlN1Y2NlZWRlZCIsIm1lc3NhZ2UiOiJBbGwgU3RlcHMgaGF2ZSBjb21wbGV0ZWQgZXhlY3V0aW5nIn1dLCJwb2ROYW1lIjoic2ltcGxlLWJ1aWxkLXJ1bi1jOTgzNTA4NGVmLWJ1aWxkLXBvZCIsInN0YXJ0VGltZSI6IjIwMjMtMTAtMTdUMTY6MTE6MjNaIiwiY29tcGxldGlvblRpbWUiOiIyMDIzLTEwLTE3VDE2OjExOjI2WiIsInN0ZXBzIjpbeyJ0ZXJtaW5hdGVkIjp7ImV4aXRDb2RlIjowLCJyZWFzb24iOiJDb21wbGV0ZWQiLCJtZXNzYWdlIjoiW3tcImtleVwiOlwiSU1BR0VfRElHRVNUXCIsXCJ2YWx1ZVwiOlwic2hhMjU2OmU3MGViMmY0MTYwNWZmODYzNWU2OTUxMTI3OWM0YzhiM2VkZDlmNWYwMWM0NWQwNGYzNjk5NjVkZDc5YTc2NDBcIixcInR5cGVcIjoxfSx7XCJrZXlcIjpcIklNQUdFX1VSTFwiLFwidmFsdWVcIjpcInF1YXkuaW8vbHVjYXJ2YWwvdGVzdC1wb2xpY2llcy1jaGFpbnNcIixcInR5cGVcIjoxfV0iLCJzdGFydGVkQXQiOiIyMDIzLTEwLTE3VDE2OjExOjI2WiIsImZpbmlzaGVkQXQiOiIyMDIzLTEwLTE3VDE2OjExOjI2WiIsImNvbnRhaW5lcklEIjoiY29udGFpbmVyZDovL2Q2OWViNGNlMzc0YTY2NTM0NmJkMzM1NjhkOTI4MDZjMGU0NTE1ZTU5YmRkNmFiMDA4Y2Q4OGRkMjkwMzI0Y2IifSwibmFtZSI6ImJ1aWxkLWFuZC1wdXNoIiwiY29udGFpbmVyIjoic3RlcC1idWlsZC1hbmQtcHVzaCIsImltYWdlSUQiOiJyZWdpc3RyeS5hY2Nlc3MucmVkaGF0LmNvbS91Ymk5QHNoYTI1NjoyMGY2OTVkMmE5MTM1MmQ0ZWFhMjUxMDc1MzUxMjY3MjdiNTk0NWJmZjM4ZWQzNmEzZTU5NTkwZjQ5NTA0NmYwIn1dLCJ0YXNrUmVzdWx0cyI6W3sibmFtZSI6IklNQUdFX0RJR0VTVCIsInR5cGUiOiJzdHJpbmciLCJ2YWx1ZSI6InNoYTI1NjplNzBlYjJmNDE2MDVmZjg2MzVlNjk1MTEyNzljNGM4YjNlZGQ5ZjVmMDFjNDVkMDRmMzY5OTY1ZGQ3OWE3NjQwIn0seyJuYW1lIjoiSU1BR0VfVVJMIiwidHlwZSI6InN0cmluZyIsInZhbHVlIjoicXVheS5pby9sdWNhcnZhbC90ZXN0LXBvbGljaWVzLWNoYWlucyJ9XSwidGFza1NwZWMiOnsicGFyYW1zIjpbeyJuYW1lIjoiSU1BR0VfVVJMIiwidHlwZSI6InN0cmluZyIsImRlc2NyaXB0aW9uIjoiVGhlIHZhbHVlIHRvIG9mIHRoZSBJTUFHRV9VUkwgY29tbWl0IHJlc3VsdC4ifSx7Im5hbWUiOiJJTUFHRV9ESUdFU1QiLCJ0eXBlIjoic3RyaW5nIiwiZGVzY3JpcHRpb24iOiJUaGUgdmFsdWUgb2YgdGhlIElNQUdFX0RJR0VTVCByZXN1bHQuIn1dLCJkZXNjcmlwdGlvbiI6IlRoaXMgaXMgYSBkdW1teSB0YXNrIHRoYXQgZW11bGF0ZXMgYSB0YXNrIHRoYXQgcGVyZm9ybXMgY29udGFpbmVyIGJ1aWxkIGFuZCBwdXNoLiBJdHMgc29sZSBwdXJwb3NlIGlzIHRvIGZhY2lsaXRhdGUgdGVzdGluZy4iLCJzdGVwcyI6W3sibmFtZSI6ImJ1aWxkLWFuZC1wdXNoIiwiaW1hZ2UiOiJyZWdpc3RyeS5hY2Nlc3MucmVkaGF0LmNvbS91Ymk5OmxhdGVzdCIsImVudiI6W3sibmFtZSI6IklNQUdFX1VSTCIsInZhbHVlIjoicXVheS5pby9sdWNhcnZhbC90ZXN0LXBvbGljaWVzLWNoYWlucyJ9LHsibmFtZSI6IklNQUdFX0RJR0VTVCIsInZhbHVlIjoic2hhMjU2OmU3MGViMmY0MTYwNWZmODYzNWU2OTUxMTI3OWM0YzhiM2VkZDlmNWYwMWM0NWQwNGYzNjk5NjVkZDc5YTc2NDAifV0sInJlc291cmNlcyI6e30sInNjcmlwdCI6IiMhL3Vzci9iaW4vZW52IHNoXG5zZXQgLWV1byBwaXBlZmFpbFxuXG5lY2hvIC1uIFwiJHtJTUFHRV9VUkx9XCIgXHUwMDNlIFwiL3Rla3Rvbi9yZXN1bHRzL0lNQUdFX1VSTFwiXG5lY2hvIC1uIFwiJHtJTUFHRV9ESUdFU1R9XCIgXHUwMDNlIFwiL3Rla3Rvbi9yZXN1bHRzL0lNQUdFX0RJR0VTVFwiXG4ifV0sInJlc3VsdHMiOlt7Im5hbWUiOiJJTUFHRV9VUkwiLCJ0eXBlIjoic3RyaW5nIiwiZGVzY3JpcHRpb24iOiJJbWFnZSByZXBvc2l0b3J5IHdoZXJlIHRoZSBidWlsdCBpbWFnZSB3b3VsZCBiZSBwdXNoZWQgdG8uIn0seyJuYW1lIjoiSU1BR0VfRElHRVNUIiwidHlwZSI6InN0cmluZyIsImRlc2NyaXB0aW9uIjoiRGlnZXN0IG9mIHRoZSBpbWFnZSBqdXN0IGJ1aWx0LiJ9XX0sInByb3ZlbmFuY2UiOnsicmVmU291cmNlIjp7InVyaSI6InF1YXkuaW8vbHVjYXJ2YWwvdGVzdC1wb2xpY2llcy1jaGFpbnMiLCJkaWdlc3QiOnsic2hhMjU2IjoiYTcwM2UwOGRhY2UyMDE2ODhlZjllMzdjMDIzZmFjN2IxOGMxMTY5NGI1ZDQwMjIxYTc4ODBmMjEzMTI4NzljYyJ9LCJlbnRyeVBvaW50IjoibW9jay1idWlsZCJ9LCJmZWF0dXJlRmxhZ3MiOnsiRGlzYWJsZUFmZmluaXR5QXNzaXN0YW50IjpmYWxzZSwiRGlzYWJsZUNyZWRzSW5pdCI6ZmFsc2UsIlJ1bm5pbmdJbkVudldpdGhJbmplY3RlZFNpZGVjYXJzIjp0cnVlLCJSZXF1aXJlR2l0U1NIU2VjcmV0S25vd25Ib3N0cyI6ZmFsc2UsIkVuYWJsZVRla3Rvbk9DSUJ1bmRsZXMiOmZhbHNlLCJTY29wZVdoZW5FeHByZXNzaW9uc1RvVGFzayI6ZmFsc2UsIkVuYWJsZUFQSUZpZWxkcyI6ImJldGEiLCJTZW5kQ2xvdWRFdmVudHNGb3JSdW5zIjpmYWxzZSwiQXdhaXRTaWRlY2FyUmVhZGluZXNzIjp0cnVlLCJFbmZvcmNlTm9uZmFsc2lmaWFiaWxpdHkiOiJub25lIiwiVmVyaWZpY2F0aW9uTm9NYXRjaFBvbGljeSI6Imlnbm9yZSIsIkVuYWJsZVByb3ZlbmFuY2VJblN0YXR1cyI6dHJ1ZSwiUmVzdWx0RXh0cmFjdGlvbk1ldGhvZCI6InRlcm1pbmF0aW9uLW1lc3NhZ2UiLCJNYXhSZXN1bHRTaXplIjo0MDk2LCJTZXRTZWN1cml0eUNvbnRleHQiOmZhbHNlLCJDb3NjaGVkdWxlIjoid29ya3NwYWNlcyJ9fX19",
+          "__decodedContent": {
+            "metadata": {
+              "name": "simple-build-run-c9835084ef-build",
+              "namespace": "default",
+              "uid": "5de80611-039d-42fb-8643-a7cc6e6928bb",
+              "resourceVersion": "2389",
+              "generation": 1,
+              "creationTimestamp": "2023-10-17T16:11:23Z",
+              "labels": {
+                "app.kubernetes.io/managed-by": "tekton-pipelines",
+                "tekton.dev/memberOf": "tasks",
+                "tekton.dev/pipeline": "simple-build-run-c9835084ef",
+                "tekton.dev/pipelineRun": "simple-build-run-c9835084ef",
+                "tekton.dev/pipelineTask": "build",
+                "tekton.dev/task": "mock-build"
+              },
+              "annotations": {
+                "chains.tekton.dev/signed": "true",
+                "pipeline.tekton.dev/release": "e7b5e58"
+              },
+              "ownerReferences": [
+                {
+                  "apiVersion": "tekton.dev/v1",
+                  "kind": "PipelineRun",
+                  "name": "simple-build-run-c9835084ef",
+                  "uid": "1ce2e3ba-6da1-433d-b56b-b8c3ffcf3443",
+                  "controller": true,
+                  "blockOwnerDeletion": true
+                }
+              ],
+              "finalizers": [
+                "chains.tekton.dev"
+              ],
+              "managedFields": [
+                {
+                  "manager": "controller",
+                  "operation": "Update",
+                  "apiVersion": "tekton.dev/v1",
+                  "time": "2023-10-17T16:11:23Z",
+                  "fieldsType": "FieldsV1",
+                  "fieldsV1": {
+                    "f:metadata": {
+                      "f:annotations": {
+                        ".": {},
+                        "f:pipeline.tekton.dev/release": {}
+                      },
+                      "f:labels": {
+                        ".": {},
+                        "f:tekton.dev/memberOf": {},
+                        "f:tekton.dev/pipeline": {},
+                        "f:tekton.dev/pipelineRun": {},
+                        "f:tekton.dev/pipelineTask": {},
+                        "f:tekton.dev/task": {}
+                      },
+                      "f:ownerReferences": {
+                        ".": {},
+                        "k:{\"uid\":\"1ce2e3ba-6da1-433d-b56b-b8c3ffcf3443\"}": {}
+                      }
+                    },
+                    "f:spec": {
+                      ".": {},
+                      "f:params": {},
+                      "f:serviceAccountName": {},
+                      "f:taskRef": {
+                        ".": {},
+                        "f:kind": {},
+                        "f:params": {},
+                        "f:resolver": {}
+                      }
+                    }
+                  }
+                },
+                {
+                  "manager": "controller",
+                  "operation": "Update",
+                  "apiVersion": "tekton.dev/v1",
+                  "time": "2023-10-17T16:11:26Z",
+                  "fieldsType": "FieldsV1",
+                  "fieldsV1": {
+                    "f:status": {
+                      "f:completionTime": {},
+                      "f:conditions": {},
+                      "f:podName": {},
+                      "f:provenance": {
+                        ".": {},
+                        "f:featureFlags": {
+                          ".": {},
+                          "f:AwaitSidecarReadiness": {},
+                          "f:Coschedule": {},
+                          "f:DisableAffinityAssistant": {},
+                          "f:DisableCredsInit": {},
+                          "f:EnableAPIFields": {},
+                          "f:EnableProvenanceInStatus": {},
+                          "f:EnableTektonOCIBundles": {},
+                          "f:EnforceNonfalsifiability": {},
+                          "f:MaxResultSize": {},
+                          "f:RequireGitSSHSecretKnownHosts": {},
+                          "f:ResultExtractionMethod": {},
+                          "f:RunningInEnvWithInjectedSidecars": {},
+                          "f:ScopeWhenExpressionsToTask": {},
+                          "f:SendCloudEventsForRuns": {},
+                          "f:SetSecurityContext": {},
+                          "f:VerificationNoMatchPolicy": {}
+                        },
+                        "f:refSource": {
+                          ".": {},
+                          "f:digest": {
+                            ".": {},
+                            "f:sha256": {}
+                          },
+                          "f:entryPoint": {},
+                          "f:uri": {}
+                        }
+                      },
+                      "f:results": {},
+                      "f:startTime": {},
+                      "f:steps": {},
+                      "f:taskSpec": {
+                        ".": {},
+                        "f:description": {},
+                        "f:params": {},
+                        "f:results": {},
+                        "f:steps": {}
+                      }
+                    }
+                  },
+                  "subresource": "status"
+                },
+                {
+                  "manager": "controller",
+                  "operation": "Update",
+                  "apiVersion": "tekton.dev/v1beta1",
+                  "time": "2023-10-17T16:11:30Z",
+                  "fieldsType": "FieldsV1",
+                  "fieldsV1": {
+                    "f:metadata": {
+                      "f:annotations": {
+                        "f:chains.tekton.dev/signed": {}
+                      },
+                      "f:finalizers": {
+                        ".": {},
+                        "v:\"chains.tekton.dev\"": {}
+                      }
+                    }
+                  }
+                }
+              ]
+            },
+            "spec": {
+              "params": [
+                {
+                  "name": "IMAGE_URL",
+                  "value": "quay.io/lucarval/test-policies-chains"
+                },
+                {
+                  "name": "IMAGE_DIGEST",
+                  "value": "sha256:e70eb2f41605ff8635e69511279c4c8b3edd9f5f01c45d04f369965dd79a7640"
+                }
+              ],
+              "serviceAccountName": "default",
+              "taskRef": {
+                "kind": "Task",
+                "resolver": "bundles",
+                "params": [
+                  {
+                    "name": "bundle",
+                    "value": "quay.io/lucarval/test-policies-chains@sha256:a703e08dace201688ef9e37c023fac7b18c11694b5d40221a7880f21312879cc"
+                  },
+                  {
+                    "name": "name",
+                    "value": "mock-build"
+                  },
+                  {
+                    "name": "kind",
+                    "value": "task"
+                  }
+                ]
+              },
+              "timeout": "1h0m0s"
+            },
+            "status": {
+              "conditions": [
+                {
+                  "type": "Succeeded",
+                  "status": "True",
+                  "lastTransitionTime": "2023-10-17T16:11:26Z",
+                  "reason": "Succeeded",
+                  "message": "All Steps have completed executing"
+                }
+              ],
+              "podName": "simple-build-run-c9835084ef-build-pod",
+              "startTime": "2023-10-17T16:11:23Z",
+              "completionTime": "2023-10-17T16:11:26Z",
+              "steps": [
+                {
+                  "terminated": {
+                    "exitCode": 0,
+                    "reason": "Completed",
+                    "message": "[{\"key\":\"IMAGE_DIGEST\",\"value\":\"sha256:e70eb2f41605ff8635e69511279c4c8b3edd9f5f01c45d04f369965dd79a7640\",\"type\":1},{\"key\":\"IMAGE_URL\",\"value\":\"quay.io/lucarval/test-policies-chains\",\"type\":1}]",
+                    "startedAt": "2023-10-17T16:11:26Z",
+                    "finishedAt": "2023-10-17T16:11:26Z",
+                    "containerID": "containerd://d69eb4ce374a665346bd33568d92806c0e4515e59bdd6ab008cd88dd290324cb"
+                  },
+                  "name": "build-and-push",
+                  "container": "step-build-and-push",
+                  "imageID": "registry.access.redhat.com/ubi9@sha256:20f695d2a91352d4eaa25107535126727b5945bff38ed36a3e59590f495046f0"
+                }
+              ],
+              "taskResults": [
+                {
+                  "name": "IMAGE_DIGEST",
+                  "type": "string",
+                  "value": "sha256:e70eb2f41605ff8635e69511279c4c8b3edd9f5f01c45d04f369965dd79a7640"
+                },
+                {
+                  "name": "IMAGE_URL",
+                  "type": "string",
+                  "value": "quay.io/lucarval/test-policies-chains"
+                }
+              ],
+              "taskSpec": {
+                "params": [
+                  {
+                    "name": "IMAGE_URL",
+                    "type": "string",
+                    "description": "The value to of the IMAGE_URL commit result."
+                  },
+                  {
+                    "name": "IMAGE_DIGEST",
+                    "type": "string",
+                    "description": "The value of the IMAGE_DIGEST result."
+                  }
+                ],
+                "description": "This is a dummy task that emulates a task that performs container build and push. Its sole purpose is to facilitate testing.",
+                "steps": [
+                  {
+                    "name": "build-and-push",
+                    "image": "registry.access.redhat.com/ubi9:latest",
+                    "env": [
+                      {
+                        "name": "IMAGE_URL",
+                        "value": "quay.io/lucarval/test-policies-chains"
+                      },
+                      {
+                        "name": "IMAGE_DIGEST",
+                        "value": "sha256:e70eb2f41605ff8635e69511279c4c8b3edd9f5f01c45d04f369965dd79a7640"
+                      }
+                    ],
+                    "resources": {},
+                    "script": "#!/usr/bin/env sh\nset -euo pipefail\n\necho -n \"${IMAGE_URL}\" > \"/tekton/results/IMAGE_URL\"\necho -n \"${IMAGE_DIGEST}\" > \"/tekton/results/IMAGE_DIGEST\"\n"
+                  }
+                ],
+                "results": [
+                  {
+                    "name": "IMAGE_URL",
+                    "type": "string",
+                    "description": "Image repository where the built image would be pushed to."
+                  },
+                  {
+                    "name": "IMAGE_DIGEST",
+                    "type": "string",
+                    "description": "Digest of the image just built."
+                  }
+                ]
+              },
+              "provenance": {
+                "refSource": {
+                  "uri": "quay.io/lucarval/test-policies-chains",
+                  "digest": {
+                    "sha256": "a703e08dace201688ef9e37c023fac7b18c11694b5d40221a7880f21312879cc"
+                  },
+                  "entryPoint": "mock-build"
+                },
+                "featureFlags": {
+                  "DisableAffinityAssistant": false,
+                  "DisableCredsInit": false,
+                  "RunningInEnvWithInjectedSidecars": true,
+                  "RequireGitSSHSecretKnownHosts": false,
+                  "EnableTektonOCIBundles": false,
+                  "ScopeWhenExpressionsToTask": false,
+                  "EnableAPIFields": "beta",
+                  "SendCloudEventsForRuns": false,
+                  "AwaitSidecarReadiness": true,
+                  "EnforceNonfalsifiability": "none",
+                  "VerificationNoMatchPolicy": "ignore",
+                  "EnableProvenanceInStatus": true,
+                  "ResultExtractionMethod": "termination-message",
+                  "MaxResultSize": 4096,
+                  "SetSecurityContext": false,
+                  "Coschedule": "workspaces"
+                }
+              }
+            }
+          }
+        },
+        {
+          "uri": "git+gitspam.spam/spam/spam.git",
+          "digest": {
+            "sha1": "de952de1e1afb39b7ffd05c03cb76617cd36fed0"
+          },
+          "name": "inputs/result"
+        }
+      ]
+    },
+    "runDetails": {
+      "builder": {
+        "id": "https://tekton.dev/chains/v2"
+      },
+      "metadata": {
+        "invocationID": "1ce2e3ba-6da1-433d-b56b-b8c3ffcf3443",
+        "startedOn": "2023-10-17T16:11:12Z",
+        "finishedOn": "2023-10-17T16:11:27Z"
+      },
+      "byproducts": [
+        {
+          "name": "pipelineRunResults/IMAGE_URL",
+          "mediaType": "application/json",
+          "content": "InF1YXkuaW8vbHVjYXJ2YWwvdGVzdC1wb2xpY2llcy1jaGFpbnMi",
+          "__decodedContent": "quay.io/lucarval/test-policies-chains"
+        },
+        {
+          "name": "pipelineRunResults/IMAGE_DIGEST",
+          "mediaType": "application/json",
+          "content": "InNoYTI1NjplNzBlYjJmNDE2MDVmZjg2MzVlNjk1MTEyNzljNGM4YjNlZGQ5ZjVmMDFjNDVkMDRmMzY5OTY1ZGQ3OWE3NjQwIg==",
+          "__decodedContent": "sha256:e70eb2f41605ff8635e69511279c4c8b3edd9f5f01c45d04f369965dd79a7640"
+        },
+        {
+          "name": "pipelineRunResults/CHAINS-GIT_URL",
+          "mediaType": "application/json",
+          "content": "ImdpdHNwYW0uc3BhbS9zcGFtL3NwYW0i",
+          "__decodedContent": "gitspam.spam/spam/spam"
+        },
+        {
+          "name": "pipelineRunResults/CHAINS-GIT_COMMIT",
+          "mediaType": "application/json",
+          "content": "ImRlOTUyZGUxZTFhZmIzOWI3ZmZkMDVjMDNjYjc2NjE3Y2QzNmZlZDAi",
+          "__decodedContent": "de952de1e1afb39b7ffd05c03cb76617cd36fed0"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Seeing what is inside those base64 encoded fields is quite useful. This adds a script to use jq to inject the decoded value for each of the content fields in the attestations.

I decided to write the modified attestations to separate files so the pristine recordings are still available.