### PR TITLE
No need to format the shell script

### DIFF
--- a/tash/shell.go
+++ b/tash/shell.go
@@ -123,15 +123,6 @@ func replaceLiterals(f *syntax.File, rx map[*regexp.Regexp]string) []*syntax.Stm
 	return f.Stmts
 }
 
-var tektonVariables = regexp.MustCompile(`\$\( (results|params|workspaces|credentials|context|steps)\b`)
-
-// fixTektonVariables ensures references to a Tekton variable do not contain a leading space as that
-// prevents Tekton from processing them. For example, "$( results" is replaced with "$(results"
-// https://tekton.dev/docs/pipelines/variables/#variables-available-in-a-task
-func fixTektonVariables(buf bytes.Buffer) string {
-	return tektonVariables.ReplaceAllString(buf.String(), "$($1")
-}
-
 func formatScripts(task *pipeline.Task) error {
 	for i := range task.Spec.Steps {
 		if !isShell(task.Spec.Steps[i].Script) {

--- a/tash/ta.go
+++ b/tash/ta.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
-	"github.com/zregvart/tkn-fmt/format"
 	core "k8s.io/api/core/v1"
 )
 
@@ -257,7 +256,7 @@ func perform(task *pipeline.Task, recipe *Recipe) error {
 			return err
 		}
 
-		task.Spec.Steps[i].Script = format.FixTektonVariables(buf)
+		task.Spec.Steps[i].Script = buf.String()
 	}
 
 	if recipe.useSource || recipe.useCachi2 {


### PR DESCRIPTION
This is done already in `writeTask`.