### PR TITLE
tash: improve replacements handling

### DIFF
--- a/tash/golden/source-build/base.yaml
+++ b/tash/golden/source-build/base.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/version: "0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
-    tekton.dev/tags: "appstudio"
+    tekton.dev/tags: "konflux"
 spec:
   description: Source image build.
   params:
@@ -16,9 +16,10 @@ spec:
       type: string
     - name: BASE_IMAGES
       description: >-
-        Base images used to build the binary image. Each image per line in the same order of FROM
-        instructions specified in a multistage Dockerfile. Default to an empty string, which means
-        to skip handling a base image.
+        By default, the task inspects the SBOM of the binary image to find the base image.
+        With this parameter, you can override that behavior and pass the base image directly.
+        The value should be a newline-separated list of images, in the same order as the FROM
+        instructions specified in a multistage Dockerfile.
       type: string
       default: ""
   results:
@@ -34,9 +35,72 @@ spec:
   volumes:
     - name: source-build-work-place
       emptyDir: {}
+  stepTemplate:
+    env:
+      - name: BINARY_IMAGE
+        value: "$(params.BINARY_IMAGE)"
+      - name: BASE_IMAGES_FILE
+        value: /var/source-build/base-images.txt
+    volumeMounts:
+      - name: source-build-work-place
+        mountPath: /var/source-build
   steps:
+    - name: get-base-images
+      image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
+      env:
+        - name: BASE_IMAGES
+          value: "$(params.BASE_IMAGES)"
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        if [[ -n "$BASE_IMAGES" ]]; then
+            echo "BASE_IMAGES param received:"
+            printf "%s" "$BASE_IMAGES" | tee "$BASE_IMAGES_FILE"
+            exit
+        fi
+
+        echo "BASE_IMAGES param is empty, inspecting the SBOM instead"
+
+        raw_inspect=$(skopeo inspect --raw "docker://$BINARY_IMAGE")
+        if manifest_digest=$(jq -e -r '.manifests[0].digest' <<< "$raw_inspect"); then
+            # The BINARY_IMAGE is an index image, each manifest in the list has its own SBOM.
+            # We're gonna assume the base images are the same or similar enough in all the SBOMs.
+            echo "BINARY_IMAGE ($BINARY_IMAGE) is a manifest list, picking an arbitrary image from the list"
+            image_without_digest=${BINARY_IMAGE%@*}
+            image_without_tag=${image_without_digest%:*}
+            image=${image_without_tag}@${manifest_digest}
+        else
+            # The image is a single manifest
+            image=$BINARY_IMAGE
+        fi
+
+        for i in {1..5}; do
+            echo "Downloading SBOM for $image (attempt $i)"
+            sbom=$(cosign download sbom "$image") && break
+            [[ "$i" -lt 5 ]] && sleep 1
+        done
+
+        if [[ -z "$sbom" ]]; then
+            echo "Failed to download SBOM after 5 attempts. Proceeding anyway."
+            echo "WARNING: the source image will not include sources for the base image."
+            exit 0
+        fi
+
+        echo -n "Looking for base image in SBOM"
+        echo " (.formulation[].components[] with 'konflux:container:is_base_image' property)"
+        # Note: the SBOM should contain at most one image with the is_base_image property - the
+        # base image for the last FROM instruction. That is the only base image we care about.
+        jq -r '
+            .formulation[]?
+            | .components[]?
+            | select(any(.properties[]?; .name == "konflux:container:is_base_image"))
+            | (.purl | capture("^pkg:oci/.*?@(?<digest>.*?:[a-f0-9]*)")) as $matched
+            | .name + "@" + $matched.digest
+        ' <<< "$sbom" | tee "$BASE_IMAGES_FILE"
+
     - name: build
-      image: quay.io/redhat-appstudio/build-definitions-source-image-build-utils@sha256:cd87bbe51f1c22ff7578f5c9caf19db4f9ee7aefd0307288383b9bd478cdf856
+      image: quay.io/konflux-ci/source-container-build:9ad131acf5154d2f280b7b46a1abc543952d325c@sha256:94271c32e4578208ac90308695d2b625d4e932d65f0cdd116b200c39228f5ece
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       computeResources:
@@ -51,16 +115,9 @@ spec:
         capabilities:
           add:
             - SETFCAP
-      volumeMounts:
-        - name: source-build-work-place
-          mountPath: /var/source-build
       env:
-        - name: BINARY_IMAGE
-          value: "$(params.BINARY_IMAGE)"
         - name: SOURCE_DIR
           value: "$(workspaces.workspace.path)/source"
-        - name: BASE_IMAGES
-          value: "$(params.BASE_IMAGES)"
         - name: RESULT_FILE
           value: "$(results.BUILD_RESULT.path)"
         - name: CACHI2_ARTIFACTS_DIR
@@ -87,16 +144,18 @@ spec:
         ##
         git config --global --add safe.directory $SOURCE_DIR
 
+        base_images=$(if [[ -f "$BASE_IMAGES_FILE" ]]; then cat "$BASE_IMAGES_FILE"; fi)
+
         ${app_dir}/appenv/bin/python3 ${app_dir}/source_build.py \
           --output-binary-image "$BINARY_IMAGE" \
           --workspace /var/source-build \
           --source-dir "$SOURCE_DIR" \
-          --base-images "$BASE_IMAGES" \
+          --base-images "$base_images" \
           --write-result-to "$RESULT_FILE" \
           --cachi2-artifacts-dir "$CACHI2_ARTIFACTS_DIR" \
           --registry-allowlist="$registry_allowlist"
 
-        cat "$RESULT_FILE" | jq -r ".image_url" >"$RESULT_SOURCE_IMAGE_URL"
-        cat "$RESULT_FILE" | jq -r ".image_digest" >"$RESULT_SOURCE_IMAGE_DIGEST"
+        cat "$RESULT_FILE" | jq -j ".image_url" >"$RESULT_SOURCE_IMAGE_URL"
+        cat "$RESULT_FILE" | jq -j ".image_digest" >"$RESULT_SOURCE_IMAGE_DIGEST"
 
         cp "$RESULT_FILE" "$WS_BUILD_RESULT_FILE"

--- a/tash/golden/source-build/ta.yaml
+++ b/tash/golden/source-build/ta.yaml
@@ -3,46 +3,54 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: source-build-oci-ta
+  annotations:
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: konflux
   labels:
     app.kubernetes.io/version: "0.1"
-  annotations:
-    tekton.dev/pipelines.minVersion: "0.12.1"
-    tekton.dev/tags: "appstudio"
 spec:
   description: Source image build.
   params:
-    - name: BINARY_IMAGE
-      description: Binary image name from which to generate the source image name.
-      type: string
     - name: BASE_IMAGES
-      description: >-
-        Base images used to build the binary image. Each image per line in the same order of FROM
-        instructions specified in a multistage Dockerfile. Default to an empty string, which means
-        to skip handling a base image.
+      description: By default, the task inspects the SBOM of the binary image
+        to find the base image. With this parameter, you can override that
+        behavior and pass the base image directly. The value should be a newline-separated
+        list of images, in the same order as the FROM instructions specified
+        in a multistage Dockerfile.
+      type: string
+      default: ""
+    - name: BINARY_IMAGE
+      description: Binary image name from which to generate the source image
+        name.
+      type: string
+    - name: CACHI2_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the prefetched dependencies.
       type: string
       default: ""
     - name: SOURCE_ARTIFACT
-      description: The Trusted Artifact URI pointing to the artifact with the application source code.
+      description: The Trusted Artifact URI pointing to the artifact with
+        the application source code.
       type: string
-    - name: CACHI2_ARTIFACT
-      description: The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.
-      type: string
-      default: ""
-
   results:
     - name: BUILD_RESULT
       description: Build result.
-    - name: SOURCE_IMAGE_URL
-      description: The source image url.
     - name: SOURCE_IMAGE_DIGEST
       description: The source image digest.
+    - name: SOURCE_IMAGE_URL
+      description: The source image url.
   volumes:
     - name: workdir
       emptyDir: {}
   stepTemplate:
+    env:
+      - name: BASE_IMAGES_FILE
+        value: /var/workdir/base-images.txt
+      - name: BINARY_IMAGE
+        value: $(params.BINARY_IMAGE)
     volumeMounts:
-      - name: workdir
-        mountPath: /var/workdir
+      - mountPath: /var/workdir
+        name: workdir
   steps:
     - name: use-trusted-artifact
       image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:placeholder
@@ -50,37 +58,75 @@ spec:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
         - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
-    - name: build
-      image: quay.io/redhat-appstudio/build-definitions-source-image-build-utils@sha256:cd87bbe51f1c22ff7578f5c9caf19db4f9ee7aefd0307288383b9bd478cdf856
-      computeResources:
-        limits:
-          memory: 2Gi
-        requests:
-          memory: 512Mi
-          cpu: 250m
-      workingDir: "/var/workdir"
-      securityContext:
-        runAsUser: 0
-        capabilities:
-          add:
-            - SETFCAP
+    - name: get-base-images
+      image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
       env:
-        - name: BINARY_IMAGE
-          value: "$(params.BINARY_IMAGE)"
-        - name: SOURCE_DIR
-          value: "/var/workdir/source"
         - name: BASE_IMAGES
-          value: "$(params.BASE_IMAGES)"
+          value: $(params.BASE_IMAGES)
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        if [[ -n "$BASE_IMAGES" ]]; then
+            echo "BASE_IMAGES param received:"
+            printf "%s" "$BASE_IMAGES" | tee "$BASE_IMAGES_FILE"
+            exit
+        fi
+
+        echo "BASE_IMAGES param is empty, inspecting the SBOM instead"
+
+        raw_inspect=$(skopeo inspect --raw "docker://$BINARY_IMAGE")
+        if manifest_digest=$(jq -e -r '.manifests[0].digest' <<<"$raw_inspect"); then
+            # The BINARY_IMAGE is an index image, each manifest in the list has its own SBOM.
+            # We're gonna assume the base images are the same or similar enough in all the SBOMs.
+            echo "BINARY_IMAGE ($BINARY_IMAGE) is a manifest list, picking an arbitrary image from the list"
+            image_without_digest=${BINARY_IMAGE%@*}
+            image_without_tag=${image_without_digest%:*}
+            image=${image_without_tag}@${manifest_digest}
+        else
+            # The image is a single manifest
+            image=$BINARY_IMAGE
+        fi
+
+        for i in {1..5}; do
+            echo "Downloading SBOM for $image (attempt $i)"
+            sbom=$(cosign download sbom "$image") && break
+            [[ "$i" -lt 5 ]] && sleep 1
+        done
+
+        if [[ -z "$sbom" ]]; then
+            echo "Failed to download SBOM after 5 attempts. Proceeding anyway."
+            echo "WARNING: the source image will not include sources for the base image."
+            exit 0
+        fi
+
+        echo -n "Looking for base image in SBOM"
+        echo " (.formulation[].components[] with 'konflux:container:is_base_image' property)"
+        # Note: the SBOM should contain at most one image with the is_base_image property - the
+        # base image for the last FROM instruction. That is the only base image we care about.
+        jq -r '
+            .formulation[]?
+            | .components[]?
+            | select(any(.properties[]?; .name == "konflux:container:is_base_image"))
+            | (.purl | capture("^pkg:oci/.*?@(?<digest>.*?:[a-f0-9]*)")) as $matched
+            | .name + "@" + $matched.digest
+        ' <<<"$sbom"  | tee "$BASE_IMAGES_FILE"
+    - name: build
+      image: quay.io/konflux-ci/source-container-build:9ad131acf5154d2f280b7b46a1abc543952d325c@sha256:94271c32e4578208ac90308695d2b625d4e932d65f0cdd116b200c39228f5ece
+      workingDir: /var/workdir
+      env:
+        - name: SOURCE_DIR
+          value: /var/workdir/source
         - name: RESULT_FILE
-          value: "$(results.BUILD_RESULT.path)"
+          value: $(results.BUILD_RESULT.path)
         - name: CACHI2_ARTIFACTS_DIR
-          value: "/var/workdir/cachi2"
+          value: /var/workdir/cachi2
         - name: RESULT_SOURCE_IMAGE_URL
-          value: "$(results.SOURCE_IMAGE_URL.path)"
+          value: $(results.SOURCE_IMAGE_URL.path)
         - name: RESULT_SOURCE_IMAGE_DIGEST
-          value: "$(results.SOURCE_IMAGE_DIGEST.path)"
+          value: $(results.SOURCE_IMAGE_DIGEST.path)
         - name: WS_BUILD_RESULT_FILE
-          value: "/var/workdir/source_build_result.json"
+          value: /var/workdir/source_build_result.json
       script: |
         #!/usr/bin/env bash
         set -euo pipefail
@@ -97,16 +143,29 @@ spec:
         ##
         git config --global --add safe.directory $SOURCE_DIR
 
+        base_images=$(if [[ -f "$BASE_IMAGES_FILE" ]]; then cat "$BASE_IMAGES_FILE"; fi)
+
         ${app_dir}/appenv/bin/python3 ${app_dir}/source_build.py \
           --output-binary-image "$BINARY_IMAGE" \
           --workspace /var/workdir \
           --source-dir "$SOURCE_DIR" \
-          --base-images "$BASE_IMAGES" \
+          --base-images "$base_images" \
           --write-result-to "$RESULT_FILE" \
           --cachi2-artifacts-dir "$CACHI2_ARTIFACTS_DIR" \
           --registry-allowlist="$registry_allowlist"
 
-        cat "$RESULT_FILE" | jq -r ".image_url" >"$RESULT_SOURCE_IMAGE_URL"
-        cat "$RESULT_FILE" | jq -r ".image_digest" >"$RESULT_SOURCE_IMAGE_DIGEST"
+        cat "$RESULT_FILE" | jq -j ".image_url" >"$RESULT_SOURCE_IMAGE_URL"
+        cat "$RESULT_FILE" | jq -j ".image_digest" >"$RESULT_SOURCE_IMAGE_DIGEST"
 
         cp "$RESULT_FILE" "$WS_BUILD_RESULT_FILE"
+      computeResources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: 250m
+          memory: 512Mi
+      securityContext:
+        capabilities:
+          add:
+            - SETFCAP
+        runAsUser: 0

--- a/tash/shell.go
+++ b/tash/shell.go
@@ -106,15 +106,11 @@ func removeUnusedFunctions(f *syntax.File) []*syntax.Stmt {
 func replaceLiterals(f *syntax.File, rx map[*regexp.Regexp]string) []*syntax.Stmt {
 	syntax.Walk(f, func(n syntax.Node) bool {
 		if l, ok := n.(*syntax.Lit); ok {
-			for ex, new := range rx {
-				l.Value = ex.ReplaceAllString(l.Value, new)
-			}
+			l.Value = applyRegexReplacements(l.Value, rx)
 		}
 		if s, ok := n.(*syntax.Stmt); ok {
 			for i := range s.Comments {
-				for ex, new := range rx {
-					s.Comments[i].Text = ex.ReplaceAllString(s.Comments[i].Text, new)
-				}
+				s.Comments[i].Text = applyRegexReplacements(s.Comments[i].Text, rx)
 			}
 		}
 		return true

--- a/tash/ta.go
+++ b/tash/ta.go
@@ -208,6 +208,15 @@ func perform(task *pipeline.Task, recipe *Recipe) error {
 		task.Spec.StepTemplate.Env = slices.DeleteFunc(task.Spec.StepTemplate.Env, removeEnv(&templateEnv))
 	}
 
+	rx := map[*regexp.Regexp]string{}
+	for old, new := range recipe.RegexReplacements {
+		ex, err := regexp.Compile(old)
+		if err != nil {
+			panic(err)
+		}
+		rx[ex] = new
+	}
+
 	for i := range task.Spec.Steps {
 		env := make([]string, 0, 5)
 
@@ -239,14 +248,6 @@ func perform(task *pipeline.Task, recipe *Recipe) error {
 
 		task.Spec.Steps[i].WorkingDir = applyReplacements(task.Spec.Steps[i].WorkingDir, recipe.Replacements)
 
-		rx := map[*regexp.Regexp]string{}
-		for old, new := range recipe.RegexReplacements {
-			ex, err := regexp.Compile(old)
-			if err != nil {
-				panic(err)
-			}
-			rx[ex] = new
-		}
 		for ex, new := range rx {
 			task.Spec.Steps[i].WorkingDir = ex.ReplaceAllString(task.Spec.Steps[i].WorkingDir, new)
 		}

--- a/tash/ta.go
+++ b/tash/ta.go
@@ -222,6 +222,7 @@ func perform(task *pipeline.Task, recipe *Recipe) error {
 
 		for j := range task.Spec.Steps[i].Env {
 			task.Spec.Steps[i].Env[j].Value = applyReplacements(task.Spec.Steps[i].Env[j].Value, recipe.Replacements)
+			task.Spec.Steps[i].Env[j].Value = applyRegexReplacements(task.Spec.Steps[i].Env[j].Value, rx)
 		}
 
 		task.Spec.Steps[i].Env = slices.DeleteFunc(task.Spec.Steps[i].Env, removeEnv(&env))

--- a/tash/ta.go
+++ b/tash/ta.go
@@ -247,10 +247,7 @@ func perform(task *pipeline.Task, recipe *Recipe) error {
 		}
 
 		task.Spec.Steps[i].WorkingDir = applyReplacements(task.Spec.Steps[i].WorkingDir, recipe.Replacements)
-
-		for ex, new := range rx {
-			task.Spec.Steps[i].WorkingDir = ex.ReplaceAllString(task.Spec.Steps[i].WorkingDir, new)
-		}
+		task.Spec.Steps[i].WorkingDir = applyRegexReplacements(task.Spec.Steps[i].WorkingDir, rx)
 
 		if !isShell(task.Spec.Steps[i].Script) {
 			continue

--- a/tash/tekton.go
+++ b/tash/tekton.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"regexp"
 
 	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/substitution"
@@ -35,4 +36,12 @@ func writeTask(task *pipeline.Task, writer io.Writer) error {
 
 func applyReplacements(in string, replacements map[string]string) string {
 	return substitution.ApplyReplacements(in, replacements)
+}
+
+func applyRegexReplacements(in string, replacements map[*regexp.Regexp]string) string {
+	out := in
+	for ex, new := range replacements {
+		out = ex.ReplaceAllString(out, new)
+	}
+	return out
 }


### PR DESCRIPTION
These changes are to achieve

```diff
diff --git a/task/source-build-oci-ta/0.1/source-build-oci-ta.yaml b/task/source-build-oci-ta/0.1/source-build-oci-ta.yaml
index 716ef4b..dea3257 100644
--- a/task/source-build-oci-ta/0.1/source-build-oci-ta.yaml
+++ b/task/source-build-oci-ta/0.1/source-build-oci-ta.yaml
@@ -45,7 +45,7 @@ spec:
   stepTemplate:
     env:
       - name: BASE_IMAGES_FILE
-        value: /var/source-build/base-images.txt
+        value: /var/workdir/base-images.txt
       - name: BINARY_IMAGE
         value: $(params.BINARY_IMAGE)
     volumeMounts:
```

Currently, the [recipe](https://github.com/konflux-ci/build-definitions/blob/b2739ab714c96520eb7b021a1cc30b41d97035d1/task/source-build-oci-ta/0.1/recipe.yaml#L9) removes the /var/source-build volume mount and replaces it with /var/workdir, but doesn't do so in the environment variables (causing the task to fail when trying to create a file in a non-existent directory).

Tested by running `hack/generate-ta-tasks.sh` in build-definitions. The diff pasted above was the only change.